### PR TITLE
fix: ignore warning "the field 'SelectionGroup.sgVersion' is assigned but its value is never used"

### DIFF
--- a/Runtime/SelectionGroup.cs
+++ b/Runtime/SelectionGroup.cs
@@ -30,7 +30,10 @@ namespace Unity.SelectionGroups.Runtime
         
         [SerializeField] List<Object> members = new List<Object>();
         
+#pragma warning disable 414    
         [HideInInspector][SerializeField] private int sgVersion      = CUR_SG_VERSION; 
+#pragma warning restore 414
+        
         private const                             int CUR_SG_VERSION = (int) SGVersion.INITIAL;        
         
 


### PR DESCRIPTION
The variable is used for data versioning