### PR TITLE
Selection groups window header

### DIFF
--- a/Editor/SelectionGroupEditorWindow.GUI.cs
+++ b/Editor/SelectionGroupEditorWindow.GUI.cs
@@ -58,16 +58,22 @@ namespace Unity.SelectionGroups.Editor
         void DrawGUI()
         {
             m_groupsToDraw = SelectionGroupManager.GetOrCreateInstance().Groups;
+
+            Rect toolbarRect = new Rect()
+            {
+                width = position.width,
+                height = EditorGUIUtility.singleLineHeight
+            };
+            DrawToolbar(toolbarRect);
             
             var viewRect = Rect.zero;
+            viewRect.y = toolbarRect.yMax + 2;
             viewRect.width = position.width-16;
             viewRect.height = CalculateHeight(m_groupsToDraw);
-            var windowRect = new Rect(0, 0, position.width, position.height);
+            var windowRect = new Rect(0, toolbarRect.yMax + 2, position.width, position.height - toolbarRect.height - 2);
             scroll = GUI.BeginScrollView(windowRect, scroll, viewRect);
             
-            Rect cursor = new Rect(0, 0, position.width-RightMargin, EditorGUIUtility.singleLineHeight);
-            DrawToolbar(cursor);
-            cursor.y += cursor.height;
+            Rect cursor = new Rect(0, toolbarRect.yMax + 2, position.width-RightMargin, EditorGUIUtility.singleLineHeight);
 
             for (var i=0; i<m_groupsToDraw.Count; i++)
             {

--- a/Editor/SelectionGroupEditorWindow.GUI.cs
+++ b/Editor/SelectionGroupEditorWindow.GUI.cs
@@ -17,6 +17,7 @@ namespace Unity.SelectionGroups.Editor
         
         private GUIStyle   Label;
         private GUIContent sceneHeaderContent;
+        private GUIContent m_CreateDropdownConten;
 
         private static readonly Color ProTextColor = new Color(0.824f, 0.824f, 0.824f, 1f);
         
@@ -65,7 +66,7 @@ namespace Unity.SelectionGroups.Editor
             scroll = GUI.BeginScrollView(windowRect, scroll, viewRect);
             
             Rect cursor = new Rect(0, 0, position.width-RightMargin, EditorGUIUtility.singleLineHeight);
-            if (GUI.Button(cursor, AddGroup)) CreateNewGroup();
+            DrawToolbar(cursor);
             cursor.y += cursor.height;
 
             for (var i=0; i<m_groupsToDraw.Count; i++)
@@ -97,6 +98,28 @@ namespace Unity.SelectionGroups.Editor
             }
             GUI.EndScrollView();
 
+        }
+
+        void DrawToolbar(Rect rect)
+        {
+            if (Event.current.type == EventType.Repaint)
+                EditorStyles.toolbar.Draw(rect, false, false, false, false);
+
+            rect.width = 35;
+            if (EditorGUI.DropdownButton(rect, m_CreateDropdownConten, FocusType.Passive, EditorStyles.toolbarDropDown))
+            {
+                GenericMenu menu = new GenericMenu();
+                menu.AddItem(new GUIContent("Create Empty Group"), false, CreateNewGroup);
+                if (Selection.gameObjects.Length > 0)
+                {
+                    menu.AddItem(new GUIContent("Create Group from Selection"), false, CreateNewGroupFromSelection);
+                }
+                else
+                {
+                    menu.AddDisabledItem(new GUIContent("Create Group from Selection"));
+                }
+                menu.DropDown(rect);
+            }
         }
 
         void SetupStyles()

--- a/Editor/SelectionGroupEditorWindow.Messages.cs
+++ b/Editor/SelectionGroupEditorWindow.Messages.cs
@@ -22,6 +22,7 @@ namespace Unity.SelectionGroups.Editor
             wantsMouseMove = true;
             
             sceneHeaderContent     =  EditorGUIUtility.IconContent("SceneAsset Icon");
+            m_CreateDropdownConten = EditorGUIUtility.IconContent("CreateAddNew");
             Undo.undoRedoPerformed += OnUndoRedoPerformed;
         }
 

--- a/Editor/SelectionGroupEditorWindow.cs
+++ b/Editor/SelectionGroupEditorWindow.cs
@@ -59,6 +59,17 @@ namespace Unity.SelectionGroups.Editor
                 Color.HSVToRGB(Random.value, Random.Range(0.9f, 1f), Random.Range(0.9f, 1f)));
         }
 
+        static void CreateNewGroupFromSelection()
+        {
+            var sgManager = SelectionGroupManager.GetOrCreateInstance();
+            
+            int numGroups = sgManager.Groups.Count;
+            var newGroup =sgManager.CreateSceneSelectionGroup($"SG_New Group {numGroups}",
+                Color.HSVToRGB(Random.value, Random.Range(0.9f, 1f), Random.Range(0.9f, 1f)));
+
+            newGroup.Add(Selection.gameObjects);
+        }
+
         static void RegisterUndo(SelectionGroup group, string msg)
         {
             Undo.RegisterCompleteObjectUndo(group, msg);


### PR DESCRIPTION
Changed the header/toolbar of the Selection Groups window to be a toolbar with a dropdown button to create a group or group from selection.
Also moved the toolbar so it is no longer inside of the scrollview.