### PR TITLE
Code style cleanup

### DIFF
--- a/Editor/Scripts/ProjectSettings/SelectionGroupsProjectSettingsProvider.cs
+++ b/Editor/Scripts/ProjectSettings/SelectionGroupsProjectSettingsProvider.cs
@@ -49,7 +49,7 @@ class SelectionGroupsProjectSettingsProvider : SettingsProvider {
                 }
             );
 
-            for (int i = 0; i < (int)SelectionGroupToolType.BUILT_IN_MAX; ++i) {
+            for (int i = 0; i < (int)SelectionGroupToolType.BuiltInMAX; ++i) {
                 int toolID = i;
                 UIElementsEditorUtility.AddField<Toggle, bool>(defaultSectionContainer, 
                     Contents.DEFAULT_GROUP_EDITOR_TOOL[i], 

--- a/Editor/Scripts/ProjectSettings/SelectionGroupsProjectSettingsProvider.cs
+++ b/Editor/Scripts/ProjectSettings/SelectionGroupsProjectSettingsProvider.cs
@@ -87,7 +87,7 @@ class SelectionGroupsProjectSettingsProvider : SettingsProvider {
     
     internal void RefreshGroupHideFlagsInEditor() {
         SelectionGroupManager sgManager = SelectionGroupManager.GetOrCreateInstance();
-        foreach (SelectionGroup group in sgManager.Groups) {
+        foreach (SelectionGroup group in sgManager.groups) {
             group.RefreshHideFlagsInEditor();
         }
         SelectionGroupManager.UpdateQueryResults();

--- a/Editor/Scripts/ProjectSettings/SelectionGroupsProjectSettingsProvider.cs
+++ b/Editor/Scripts/ProjectSettings/SelectionGroupsProjectSettingsProvider.cs
@@ -25,12 +25,12 @@ class SelectionGroupsProjectSettingsProvider : SettingsProvider {
         activateHandler = (string searchContext, VisualElement root) => {
             //Main Tree
             VisualTreeAsset main =
-                UIElementsEditorUtility.LoadVisualTreeAsset(SelectionGroupEditorConstants.MAIN_PROJECT_SETTINGS_PATH);
+                UIElementsEditorUtility.LoadVisualTreeAsset(SelectionGroupEditorConstants.MainProjectSettingsPath);
             main.CloneTree(root);
 
             //Style
             UIElementsEditorUtility.LoadAndAddStyle(root.styleSheets,
-                SelectionGroupEditorConstants.PROJECT_SETTINGS_STYLE_PATH);
+                SelectionGroupEditorConstants.ProjectSettingsStylePath);
 
             //add fields
             VisualElement defaultSectionContainer = root.Query<VisualElement>("DefaultSectionContainer");

--- a/Editor/Scripts/ProjectSettings/SelectionGroupsProjectSettingsProvider.cs
+++ b/Editor/Scripts/ProjectSettings/SelectionGroupsProjectSettingsProvider.cs
@@ -6,103 +6,99 @@ using UnityEngine.Assertions;
 using UnityEngine.UIElements;
 
 namespace Unity.SelectionGroups.Editor {
-class SelectionGroupsProjectSettingsProvider : SettingsProvider {
-    private class Contents {
-		public static readonly GUIContent SHOW_GROUPS_IN_HIERARCHY = EditorGUIUtility.TrTextContent("Show groups in Hierarchy");
+    internal class SelectionGroupsProjectSettingsProvider : SettingsProvider 
+    {
+        private class Contents 
+        {
+		    public static readonly GUIContent ShowGroupsInHierarchy = EditorGUIUtility.TrTextContent("Show groups in Hierarchy");
 
-        public static readonly GUIContent[] DEFAULT_GROUP_EDITOR_TOOL = new GUIContent[] {
-            EditorGUIUtility.TrTextContent("Enable eye toolbar button by default"),
-            EditorGUIUtility.TrTextContent("Enable lock toolbar button by default"),
-        };
+            public static readonly GUIContent[] DefaultGroupEditorTool = new GUIContent[] 
+            {
+                EditorGUIUtility.TrTextContent("Enable eye toolbar button by default"),
+                EditorGUIUtility.TrTextContent("Enable lock toolbar button by default"),
+            };
+        }
+        
+        private const string kProjectSettingsMenuPath = "Project/Selection Groups";
+        
+        private static SelectionGroupsProjectSettingsProvider s_ProjectSettingsProvider = null;
 
-    }
+        private SelectionGroupsProjectSettingsProvider() : base(kProjectSettingsMenuPath, SettingsScope.Project) 
+        {
+            //activateHandler is called when the user clicks on the Settings item in the Settings window.
+            activateHandler = (string searchContext, VisualElement root) => 
+            {
+                //Main Tree
+                VisualTreeAsset main =
+                    UIElementsEditorUtility.LoadVisualTreeAsset(SelectionGroupEditorConstants.MainProjectSettingsPath);
+                main.CloneTree(root);
 
+                //Style
+                UIElementsEditorUtility.LoadAndAddStyle(root.styleSheets,
+                    SelectionGroupEditorConstants.ProjectSettingsStylePath);
 
-//----------------------------------------------------------------------------------------------------------------------		
+                //add fields
+                VisualElement defaultSectionContainer = root.Query<VisualElement>("DefaultSectionContainer");
+                Assert.IsNotNull(defaultSectionContainer);
 
-    SelectionGroupsProjectSettingsProvider() : base(PROJECT_SETTINGS_MENU_PATH, SettingsScope.Project) {
-        //activateHandler is called when the user clicks on the Settings item in the Settings window.
-        activateHandler = (string searchContext, VisualElement root) => {
-            //Main Tree
-            VisualTreeAsset main =
-                UIElementsEditorUtility.LoadVisualTreeAsset(SelectionGroupEditorConstants.MainProjectSettingsPath);
-            main.CloneTree(root);
-
-            //Style
-            UIElementsEditorUtility.LoadAndAddStyle(root.styleSheets,
-                SelectionGroupEditorConstants.ProjectSettingsStylePath);
-
-            //add fields
-            VisualElement defaultSectionContainer = root.Query<VisualElement>("DefaultSectionContainer");
-            Assert.IsNotNull(defaultSectionContainer);
-
-            SelectionGroupsEditorProjectSettings projSettings =
-                SelectionGroupsEditorProjectSettings.GetOrCreateInstance();
-            
-            
-            UIElementsEditorUtility.AddField<Toggle, bool>(defaultSectionContainer, Contents.SHOW_GROUPS_IN_HIERARCHY, 
-                projSettings.AreGroupsVisibleInHierarchy(),
-                (e) => {
-                    projSettings.ShowGroupsInHierarchy(e.newValue);
-                    projSettings.SaveInEditor();
-                    RefreshGroupHideFlagsInEditor();
-                }
-            );
-
-            for (int i = 0; i < (int)SelectionGroupToolType.BuiltInMAX; ++i) {
-                int toolID = i;
-                UIElementsEditorUtility.AddField<Toggle, bool>(defaultSectionContainer, 
-                    Contents.DEFAULT_GROUP_EDITOR_TOOL[i], 
-                    projSettings.GetDefaultGroupEditorToolState(toolID),
-                    (e) => {
-                        projSettings.EnableDefaultGroupEditorTool(toolID, e.newValue);
+                SelectionGroupsEditorProjectSettings projSettings =
+                    SelectionGroupsEditorProjectSettings.GetOrCreateInstance();
+                
+                
+                UIElementsEditorUtility.AddField<Toggle, bool>(defaultSectionContainer, Contents.ShowGroupsInHierarchy, 
+                    projSettings.AreGroupsVisibleInHierarchy(),
+                    (e) => 
+                    {
+                        projSettings.ShowGroupsInHierarchy(e.newValue);
                         projSettings.SaveInEditor();
+                        RefreshGroupHideFlagsInEditor();
                     }
                 );
-                
-            }
-            
-        };
 
-        deactivateHandler = () => { };
+                for (int i = 0; i < (int)SelectionGroupToolType.BuiltInMAX; ++i) 
+                {
+                    int toolID = i;
+                    UIElementsEditorUtility.AddField<Toggle, bool>(defaultSectionContainer, 
+                        Contents.DefaultGroupEditorTool[i], 
+                        projSettings.GetDefaultGroupEditorToolState(toolID),
+                        (e) => 
+                        {
+                            projSettings.EnableDefaultGroupEditorTool(toolID, e.newValue);
+                            projSettings.SaveInEditor();
+                        }
+                    );
+                }
+            };
 
-
-        //keywords
-        HashSet<string> sgKeywords = new HashSet<string>(new[] { "Selection Groups", "Selection Group" });
-        sgKeywords.UnionWith(GetSearchKeywordsFromGUIContentProperties<Contents>());
-        keywords = sgKeywords;
-    }
-
-
-//----------------------------------------------------------------------------------------------------------------------
-
-    [SettingsProvider]
-    internal static SettingsProvider CreateSelectionGroupsSettingsProvider() {
-        m_projectSettingsProvider = new SelectionGroupsProjectSettingsProvider();
-        return m_projectSettingsProvider;
-    }
+            deactivateHandler = () => { };
 
 
-//----------------------------------------------------------------------------------------------------------------------
-    
-    internal void RefreshGroupHideFlagsInEditor() {
-        SelectionGroupManager sgManager = SelectionGroupManager.GetOrCreateInstance();
-        foreach (SelectionGroup group in sgManager.groups) {
-            group.RefreshHideFlagsInEditor();
+            //keywords
+            HashSet<string> sgKeywords = new HashSet<string>(new[] { "Selection Groups", "Selection Group" });
+            sgKeywords.UnionWith(GetSearchKeywordsFromGUIContentProperties<Contents>());
+            keywords = sgKeywords;
         }
-        SelectionGroupManager.UpdateQueryResults();
-        EditorApplication.RepaintHierarchyWindow();
-        EditorApplication.DirtyHierarchyWindowSorting();
+
         
-        SelectionGroupEditorWindow.TryRepaint();
+        [SettingsProvider]
+        internal static SettingsProvider CreateSelectionGroupsSettingsProvider() 
+        {
+            s_ProjectSettingsProvider = new SelectionGroupsProjectSettingsProvider();
+            return s_ProjectSettingsProvider;
+        }
+        
+        internal void RefreshGroupHideFlagsInEditor() 
+        {
+            SelectionGroupManager sgManager = SelectionGroupManager.GetOrCreateInstance();
+            foreach (SelectionGroup group in sgManager.groups) 
+            {
+                group.RefreshHideFlagsInEditor();
+            }
+            SelectionGroupManager.UpdateQueryResults();
+            EditorApplication.RepaintHierarchyWindow();
+            EditorApplication.DirtyHierarchyWindowSorting();
+            
+            SelectionGroupEditorWindow.TryRepaint();
+        }
     }
-    
-
-    private static SelectionGroupsProjectSettingsProvider m_projectSettingsProvider = null;
-
-    private const string PROJECT_SETTINGS_MENU_PATH = "Project/Selection Groups";
-
-
-//----------------------------------------------------------------------------------------------------------------------
-}
 }

--- a/Editor/Scripts/SelectionGroupConfigurationDialog.cs
+++ b/Editor/Scripts/SelectionGroupConfigurationDialog.cs
@@ -60,11 +60,11 @@ namespace Unity.SelectionGroups.Editor
             using (var cc = new EditorGUI.ChangeCheckScope())
             {
                 GUILayout.Label("Selection Group Properties", EditorStyles.largeLabel);
-                group.Name = EditorGUILayout.TextField("Group Name", group.Name);
-                group.Color = EditorGUILayout.ColorField("Color", group.Color);
+                group.groupName = EditorGUILayout.TextField("Group Name", group.groupName);
+                group.color = EditorGUILayout.ColorField("Color", group.color);
                 EditorGUILayout.LabelField("GameObject Query");
-                var q = group.Query;
-                var newQuery = EditorGUILayout.TextField(group.Query);
+                var q = group.query;
+                var newQuery = EditorGUILayout.TextField(group.query);
                 refreshQuery = refreshQuery || (q != newQuery);
                 
                 if (refreshQuery)

--- a/Editor/Scripts/SelectionGroupConfigurationDialog.cs
+++ b/Editor/Scripts/SelectionGroupConfigurationDialog.cs
@@ -14,16 +14,16 @@ namespace Unity.SelectionGroups.Editor
     /// </summary>
     public class SelectionGroupConfigurationDialog : EditorWindow
     {
-        [SerializeField] int groupId;
-        ReorderableList exclusionList;
-
-        SelectionGroup group;
-        GoQL.GoQLExecutor executor = new GoQL.GoQLExecutor();
-        SelectionGroupEditorWindow parentWindow;
-        string message = string.Empty;
-        bool refreshQuery = true;
-        bool showDebug = false;
-        SelectionGroupDebugInformation debugInformation;
+        [SerializeField] private int m_GroupId;
+        
+        private ReorderableList m_ExclusionList;
+        private SelectionGroup m_Group;
+        private GoQL.GoQLExecutor m_Executor = new GoQL.GoQLExecutor();
+        private SelectionGroupEditorWindow m_ParentWindow;
+        private string m_Message = string.Empty;
+        private bool m_RefreshQuery = true;
+        private bool m_ShowDebug = false;
+        private SelectionGroupDebugInformation m_DebugInformation;
 
         private void OnEnable()
         {
@@ -33,7 +33,7 @@ namespace Unity.SelectionGroups.Editor
 
         private void OnUndoRedo()
         {
-            refreshQuery = true;
+            m_RefreshQuery = true;
             Repaint();
         }
 
@@ -42,16 +42,16 @@ namespace Unity.SelectionGroups.Editor
             Undo.undoRedoPerformed -= OnUndoRedo;
         }
 
-        void OnGUI()
+        private void OnGUI()
         {
-            if (group == null)
+            if (m_Group == null)
             {
                 Close();
                 return;
             }
 
             //Null for SelectionGroup (scene), which is a MonoBehaviour, must be checked against null using its type
-            if (group is Component component && component == null){
+            if (m_Group is Component component && component == null){
                 Close();
                 return;                
             }
@@ -60,43 +60,41 @@ namespace Unity.SelectionGroups.Editor
             using (var cc = new EditorGUI.ChangeCheckScope())
             {
                 GUILayout.Label("Selection Group Properties", EditorStyles.largeLabel);
-                group.groupName = EditorGUILayout.TextField("Group Name", group.groupName);
-                group.color = EditorGUILayout.ColorField("Color", group.color);
+                m_Group.groupName = EditorGUILayout.TextField("Group Name", m_Group.groupName);
+                m_Group.color = EditorGUILayout.ColorField("Color", m_Group.color);
                 EditorGUILayout.LabelField("GameObject Query");
-                var q = group.query;
-                var newQuery = EditorGUILayout.TextField(group.query);
-                refreshQuery = refreshQuery || (q != newQuery);
+                var q = m_Group.query;
+                var newQuery = EditorGUILayout.TextField(m_Group.query);
+                m_RefreshQuery = m_RefreshQuery || (q != newQuery);
                 
-                if (refreshQuery)
+                if (m_RefreshQuery)
                 {
                     {
-                        var obj = group as Object;
+                        var obj = m_Group as Object;
                         
                         Undo.RegisterCompleteObjectUndo(obj, "Query change");
                         
                     }
                 }
-                if (message != string.Empty)
+                if (m_Message != string.Empty)
                 {
                     GUILayout.Space(5);
-                    EditorGUILayout.HelpBox(message, MessageType.Info);
+                    EditorGUILayout.HelpBox(m_Message, MessageType.Info);
                 }
                 GUILayout.Space(5);
                 
-                showDebug = GUILayout.Toggle(showDebug, "Show Debug Info", "button");
-                if (showDebug)
+                m_ShowDebug = GUILayout.Toggle(m_ShowDebug, "Show Debug Info", "button");
+                if (m_ShowDebug)
                 {
-                    if (debugInformation == null) debugInformation = new SelectionGroupDebugInformation(group);
-                    EditorGUILayout.TextArea(debugInformation.text);
+                    if (m_DebugInformation == null) m_DebugInformation = new SelectionGroupDebugInformation(m_Group);
+                    EditorGUILayout.TextArea(m_DebugInformation.text);
                 }
                 else
                 {
-                    debugInformation = null;
+                    m_DebugInformation = null;
                 }
             }
         }
-
-        
     }
 }
 

--- a/Editor/Scripts/SelectionGroupDebugInformation.cs
+++ b/Editor/Scripts/SelectionGroupDebugInformation.cs
@@ -3,9 +3,8 @@ using UnityEditor;
 
 namespace Unity.SelectionGroups.Editor
 {
-    class SelectionGroupDebugInformation
+    internal class SelectionGroupDebugInformation
     {
-
         public string text;
 
         internal SelectionGroupDebugInformation(SelectionGroup group)

--- a/Editor/Scripts/SelectionGroupDrawer.cs
+++ b/Editor/Scripts/SelectionGroupDrawer.cs
@@ -22,7 +22,7 @@ namespace Unity.SelectionGroups.Editor
         /// <param name="label"></param>
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            if (names == null) names = SelectionGroupManager.GetOrCreateInstance().GroupNames.ToArray();
+            if (names == null) names = SelectionGroupManager.GetOrCreateInstance().groupNames.ToArray();
             var name = property.stringValue;
             position = EditorGUI.PrefixLabel(position, label);
             var index = System.Array.IndexOf(names, name);

--- a/Editor/Scripts/SelectionGroupDrawer.cs
+++ b/Editor/Scripts/SelectionGroupDrawer.cs
@@ -12,7 +12,7 @@ namespace Unity.SelectionGroups.Editor
     [CustomPropertyDrawer(typeof(SelectionGroupDropDownAttribute))]
     public class SelectionGroupDrawer : PropertyDrawer
     {
-        string[] names;
+        private string[] m_Names;
 
         /// <summary>
         /// Implements UI for SelectionGroup drawers.
@@ -22,14 +22,14 @@ namespace Unity.SelectionGroups.Editor
         /// <param name="label"></param>
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            if (names == null) names = SelectionGroupManager.GetOrCreateInstance().groupNames.ToArray();
+            if (m_Names == null) m_Names = SelectionGroupManager.GetOrCreateInstance().groupNames.ToArray();
             var name = property.stringValue;
             position = EditorGUI.PrefixLabel(position, label);
-            var index = System.Array.IndexOf(names, name);
-            var newIndex = EditorGUI.Popup(position, index, names);
+            var index = System.Array.IndexOf(m_Names, name);
+            var newIndex = EditorGUI.Popup(position, index, m_Names);
             if (newIndex != index)
             {
-                property.stringValue = names[newIndex];
+                property.stringValue = m_Names[newIndex];
             }
         }
     }

--- a/Editor/Scripts/SelectionGroupEditorConstants.cs
+++ b/Editor/Scripts/SelectionGroupEditorConstants.cs
@@ -5,7 +5,7 @@ namespace Unity.SelectionGroups.Editor {
 internal class SelectionGroupEditorConstants {
 
     //USS
-    private static readonly  string USS_FOLDER = Path.Combine(SelectionGroupConstants.PACKAGES_PATH,"Editor/StyleSheets");
+    private static readonly  string USS_FOLDER = Path.Combine(SelectionGroupConstants.PackagesPath,"Editor/StyleSheets");
     internal static readonly string PROJECT_SETTINGS_STYLE_PATH = Path.Combine(USS_FOLDER,"ProjectSettings_Style");
     
     // XML
@@ -15,7 +15,7 @@ internal class SelectionGroupEditorConstants {
 //----------------------------------------------------------------------------------------------------------------------
     private static string ProjSettingsUIPath(string uiElementRelativePath) {
         const string UIELEMENTS_PATH = "Editor/UIElements/ProjectSettings";
-        return Path.Combine(SelectionGroupConstants.PACKAGES_PATH,UIELEMENTS_PATH,uiElementRelativePath);
+        return Path.Combine(SelectionGroupConstants.PackagesPath,UIELEMENTS_PATH,uiElementRelativePath);
         
     }
 

--- a/Editor/Scripts/SelectionGroupEditorConstants.cs
+++ b/Editor/Scripts/SelectionGroupEditorConstants.cs
@@ -1,24 +1,20 @@
 using System.IO;
 
-namespace Unity.SelectionGroups.Editor {
-
-internal class SelectionGroupEditorConstants {
-
-    //USS
-    private static readonly  string USS_FOLDER = Path.Combine(SelectionGroupConstants.PackagesPath,"Editor/StyleSheets");
-    internal static readonly string PROJECT_SETTINGS_STYLE_PATH = Path.Combine(USS_FOLDER,"ProjectSettings_Style");
-    
-    // XML
-    internal static readonly string MAIN_PROJECT_SETTINGS_PATH = ProjSettingsUIPath("ProjectSettings_Main");
-
-    
-//----------------------------------------------------------------------------------------------------------------------
-    private static string ProjSettingsUIPath(string uiElementRelativePath) {
-        const string UIELEMENTS_PATH = "Editor/UIElements/ProjectSettings";
-        return Path.Combine(SelectionGroupConstants.PackagesPath,UIELEMENTS_PATH,uiElementRelativePath);
+namespace Unity.SelectionGroups.Editor 
+{
+    internal class SelectionGroupEditorConstants 
+    {
+        //USS
+        private static readonly  string s_USSFolder = Path.Combine(SelectionGroupConstants.PackagesPath,"Editor/StyleSheets");
+        internal static readonly string ProjectSettingsStylePath = Path.Combine(s_USSFolder,"ProjectSettings_Style");
         
+        // XML
+        internal static readonly string MainProjectSettingsPath = ProjSettingsUIPath("ProjectSettings_Main");
+        
+        private static string ProjSettingsUIPath(string uiElementRelativePath) 
+        {
+            const string uielementsPath = "Editor/UIElements/ProjectSettings";
+            return Path.Combine(SelectionGroupConstants.PackagesPath, uielementsPath,uiElementRelativePath);
+        }
     }
-
 }
-
-} //end namespace

--- a/Editor/Scripts/SelectionGroupInspector.cs
+++ b/Editor/Scripts/SelectionGroupInspector.cs
@@ -6,90 +6,94 @@ using UnityEditor;
 using UnityEditor.PackageManager.UI;
 using UnityEngine;
     
-namespace Unity.SelectionGroups.Editor {
-
-[CustomEditor(typeof(SelectionGroups.SelectionGroup))]
-internal class SelectionGroupInspector : UnityEditor.Editor {
-    public override void OnInspectorGUI() {
-        serializedObject.Update();
-
-        bool repaintWindow = EditorGUIDrawerUtility.DrawUndoableGUI(m_group.gameObject, "Group Name",
-            () => EditorGUILayout.TextField("Group Name", m_group.groupName),
-            (string groupName) => { m_group.groupName = groupName; }
-        );
+namespace Unity.SelectionGroups.Editor 
+{
+    [CustomEditor(typeof(SelectionGroups.SelectionGroup))]
+    internal class SelectionGroupInspector : UnityEditor.Editor 
+    {
+        private SelectionGroup m_Group;
+        private bool m_ShowDebug  = false;
+        private SelectionGroupDebugInformation m_DebugInformation;
         
-        repaintWindow |= EditorGUIDrawerUtility.DrawUndoableGUI(m_group, "Group Color",
-            () => EditorGUILayout.ColorField("Color", m_group.color),
-            (Color groupColor) => { m_group.color = groupColor; }
-        );
-
-        repaintWindow |= EditorGUIDrawerUtility.DrawUndoableGUI(m_group, "Group Query",
-            () => EditorGUILayout.TextField("Group Query", m_group.query),
-            (string query) => {
-                {
-                    Undo.RegisterCompleteObjectUndo(m_group, "Query change");
-                }
-                m_group.SetQuery(query);
-            }
-        );
-
-        //Query results
-        if (m_group.IsAutoFilled()) {
-            GoQL.ParseResult parseResult = m_group.GetLastQueryParseResult();
-            
-            string message = (parseResult == GoQL.ParseResult.OK) 
-                ? $"{m_group.Members.Count} results." 
-                : parseResult.ToString();
-
-            GUILayout.Space(5);
-            EditorGUILayout.HelpBox(message, MessageType.Info);
+        private void OnEnable() 
+        {
+            m_Group = target as SelectionGroup;
         }
-                
-        GUILayout.BeginVertical("box");
-        GUILayout.Label("Enabled Toolbar Buttons", EditorStyles.largeLabel);
-        foreach (MethodInfo i in TypeCache.GetMethodsWithAttribute<SelectionGroupToolAttribute>()) {
-            SelectionGroupToolAttribute attr = i.GetCustomAttribute<SelectionGroupToolAttribute>();            
-            repaintWindow |= EditorGUIDrawerUtility.DrawUndoableGUI(m_group, "Group Toolbar",
-                guiFunc: () => {
-                    bool       isEnabledPrev = m_group.GetEditorToolState(attr.toolId);
-                    GUIContent content       = EditorGUIUtility.IconContent(attr.icon);
-                    return EditorGUILayout.ToggleLeft(content, isEnabledPrev, "button");
-                },
-                updateFunc: (bool toolEnabled) => {
-                    m_group.EnableEditorTool(attr.toolId, toolEnabled);
+        
+        public override void OnInspectorGUI() 
+        {
+            serializedObject.Update();
+
+            bool repaintWindow = EditorGUIDrawerUtility.DrawUndoableGUI(m_Group.gameObject, "Group Name",
+                () => EditorGUILayout.TextField("Group Name", m_Group.groupName),
+                (string groupName) => { m_Group.groupName = groupName; }
+            );
+            
+            repaintWindow |= EditorGUIDrawerUtility.DrawUndoableGUI(m_Group, "Group Color",
+                () => EditorGUILayout.ColorField("Color", m_Group.color),
+                (Color groupColor) => { m_Group.color = groupColor; }
+            );
+
+            repaintWindow |= EditorGUIDrawerUtility.DrawUndoableGUI(m_Group, "Group Query",
+                () => EditorGUILayout.TextField("Group Query", m_Group.query),
+                (string query) => 
+                {
+                    {
+                        Undo.RegisterCompleteObjectUndo(m_Group, "Query change");
+                    }
+                    m_Group.SetQuery(query);
                 }
             );
+
+            //Query results
+            if (m_Group.IsAutoFilled()) 
+            {
+                GoQL.ParseResult parseResult = m_Group.GetLastQueryParseResult();
+                
+                string message = (parseResult == GoQL.ParseResult.OK) 
+                    ? $"{m_Group.Members.Count} results." 
+                    : parseResult.ToString();
+
+                GUILayout.Space(5);
+                EditorGUILayout.HelpBox(message, MessageType.Info);
+            }
+                    
+            GUILayout.BeginVertical("box");
+            GUILayout.Label("Enabled Toolbar Buttons", EditorStyles.largeLabel);
+            foreach (MethodInfo i in TypeCache.GetMethodsWithAttribute<SelectionGroupToolAttribute>()) 
+            {
+                SelectionGroupToolAttribute attr = i.GetCustomAttribute<SelectionGroupToolAttribute>();            
+                repaintWindow |= EditorGUIDrawerUtility.DrawUndoableGUI(m_Group, "Group Toolbar",
+                    guiFunc: () => 
+                    {
+                        bool       isEnabledPrev = m_Group.GetEditorToolState(attr.toolId);
+                        GUIContent content       = EditorGUIUtility.IconContent(attr.icon);
+                        return EditorGUILayout.ToggleLeft(content, isEnabledPrev, "button");
+                    },
+                    updateFunc: (bool toolEnabled) => 
+                    {
+                        m_Group.EnableEditorTool(attr.toolId, toolEnabled);
+                    }
+                );
+            }
+            GUILayout.EndVertical();
+            
+            m_ShowDebug = GUILayout.Toggle(m_ShowDebug, "Show Debug Info", "button");
+            if (m_ShowDebug) 
+            {
+                if (m_DebugInformation == null) m_DebugInformation = new SelectionGroupDebugInformation(m_Group);
+                EditorGUILayout.TextArea(m_DebugInformation.text);
+            } 
+            else 
+            {
+                m_DebugInformation = null;
+            }
+            serializedObject.ApplyModifiedProperties();
+
+            if (!repaintWindow)
+                return;
+            
+            SelectionGroupEditorWindow.TryRepaint();
         }
-        GUILayout.EndVertical();
-        
-        m_showDebug = GUILayout.Toggle(m_showDebug, "Show Debug Info", "button");
-        if (m_showDebug) {
-            if (m_debugInformation == null) m_debugInformation = new SelectionGroupDebugInformation(m_group);
-            EditorGUILayout.TextArea(m_debugInformation.text);
-        } else {
-            m_debugInformation = null;
-        }
-        serializedObject.ApplyModifiedProperties();
-
-        if (!repaintWindow)
-            return;
-        
-        SelectionGroupEditorWindow.TryRepaint();
-
     }
-    
-//----------------------------------------------------------------------------------------------------------------------    
-    private void OnEnable() {
-        m_group = target as SelectionGroup;
-    }
-   
-//----------------------------------------------------------------------------------------------------------------------    
-    
-
-    SelectionGroup m_group;
-    
-    bool                           m_showDebug  = false;
-    SelectionGroupDebugInformation m_debugInformation;
 }
-
-} //end namespace

--- a/Editor/Scripts/SelectionGroupInspector.cs
+++ b/Editor/Scripts/SelectionGroupInspector.cs
@@ -14,17 +14,17 @@ internal class SelectionGroupInspector : UnityEditor.Editor {
         serializedObject.Update();
 
         bool repaintWindow = EditorGUIDrawerUtility.DrawUndoableGUI(m_group.gameObject, "Group Name",
-            () => EditorGUILayout.TextField("Group Name", m_group.Name),
-            (string groupName) => { m_group.Name = groupName; }
+            () => EditorGUILayout.TextField("Group Name", m_group.groupName),
+            (string groupName) => { m_group.groupName = groupName; }
         );
         
         repaintWindow |= EditorGUIDrawerUtility.DrawUndoableGUI(m_group, "Group Color",
-            () => EditorGUILayout.ColorField("Color", m_group.Color),
-            (Color groupColor) => { m_group.Color = groupColor; }
+            () => EditorGUILayout.ColorField("Color", m_group.color),
+            (Color groupColor) => { m_group.color = groupColor; }
         );
 
         repaintWindow |= EditorGUIDrawerUtility.DrawUndoableGUI(m_group, "Group Query",
-            () => EditorGUILayout.TextField("Group Query", m_group.Query),
+            () => EditorGUILayout.TextField("Group Query", m_group.query),
             (string query) => {
                 {
                     Undo.RegisterCompleteObjectUndo(m_group, "Query change");

--- a/Editor/Scripts/SelectionGroupWindow/DragDropPos.cs
+++ b/Editor/Scripts/SelectionGroupWindow/DragDropPos.cs
@@ -1,10 +1,10 @@
 ﻿
-namespace Unity.SelectionGroups.Editor {
-
-internal enum DragDropPos {
-    ABOVE = 0,
-    BELOW = 1,
-}    
-
-} //end namespace
+namespace Unity.SelectionGroups.Editor 
+{
+    internal enum DragDropPos 
+    {
+        Above = 0,
+        Below = 1,
+    }
+}
 

--- a/Editor/Scripts/SelectionGroupWindow/DragItemType.cs
+++ b/Editor/Scripts/SelectionGroupWindow/DragItemType.cs
@@ -1,12 +1,11 @@
 ﻿
-namespace Unity.SelectionGroups.Editor {
-
-internal enum DragItemType {
-    GROUP = 0,
-    WINDOW_GROUP_MEMBERS,
-    GAMEOBJECTS,
-    
-}    
-
-} //end namespace
+namespace Unity.SelectionGroups.Editor 
+{
+    internal enum DragItemType 
+    {
+        Group = 0,
+        WindowGroupMembers,
+        GameObjects
+    }
+}
 

--- a/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.GUI.cs
+++ b/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.GUI.cs
@@ -56,7 +56,7 @@ namespace Unity.SelectionGroups.Editor
 
         void DrawGUI()
         {
-            m_groupsToDraw = SelectionGroupManager.GetOrCreateInstance().Groups;
+            m_groupsToDraw = SelectionGroupManager.GetOrCreateInstance().groups;
             
             var viewRect = Rect.zero;
             viewRect.width = position.width-16;

--- a/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.GUI.cs
+++ b/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.GUI.cs
@@ -379,11 +379,11 @@ namespace Unity.SelectionGroups.Editor
                         Rect dropRect = rect;
                         dropRect.height = 2;
 
-                        DragDropPos dropPos = Editor.DragDropPos.ABOVE;
+                        DragDropPos dropPos = Editor.DragDropPos.Above;
                         float halfHeight = rect.height * 0.5f;
                         if (evt.mousePosition.y - rect.y > halfHeight) {
                             dropRect.y += rect.height + kGroupHeaderPadding;
-                            dropPos    =  Editor.DragDropPos.BELOW;
+                            dropPos    =  Editor.DragDropPos.Below;
                         }  
                         DragAndDrop.SetGenericData(kDragDropPos,dropPos);
                         
@@ -513,8 +513,8 @@ namespace Unity.SelectionGroups.Editor
                                 int srcIndex = dragGroupIndex.Value;
 
                                 if (dragGroupIndex == groupIndex
-                                    || Editor.DragDropPos.ABOVE == dropPos && srcIndex == groupIndex - 1
-                                    || Editor.DragDropPos.BELOW == dropPos && srcIndex == groupIndex + 1
+                                    || Editor.DragDropPos.Above == dropPos && srcIndex == groupIndex - 1
+                                    || Editor.DragDropPos.Below == dropPos && srcIndex == groupIndex + 1
                                    ) 
                                 {
                                     break;
@@ -522,12 +522,12 @@ namespace Unity.SelectionGroups.Editor
 
                                 //Calculate the target new index for the group correctly
                                 int targetIndex = groupIndex;
-                                if (Editor.DragDropPos.BELOW == dropPos && targetIndex < srcIndex) 
+                                if (Editor.DragDropPos.Below == dropPos && targetIndex < srcIndex) 
                                 {
                                     ++targetIndex;
                                 }
 
-                                if (Editor.DragDropPos.ABOVE == dropPos && targetIndex > srcIndex) 
+                                if (Editor.DragDropPos.Above == dropPos && targetIndex > srcIndex) 
                                 {
                                     --targetIndex;
                                 }

--- a/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.GUI.cs
+++ b/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.GUI.cs
@@ -48,7 +48,7 @@ namespace Unity.SelectionGroups.Editor
                 height += EditorGUIUtility.singleLineHeight + 3;
                 if (@group.AreMembersShownInWindow())
                 {
-                    height += @group.Count * EditorGUIUtility.singleLineHeight;
+                    height += @group.count * EditorGUIUtility.singleLineHeight;
                 }
             }
             return height;
@@ -180,7 +180,7 @@ namespace Unity.SelectionGroups.Editor
             Rect           rect    = new Rect(cursor) {x = 0, };
             GUIContent     content = sceneHeaderContent;
             
-            content.text = $"{group.Name}";
+            content.text = $"{group.groupName}";
 
             //
             const float FOLDOUT_WIDTH    = 16;
@@ -223,7 +223,7 @@ namespace Unity.SelectionGroups.Editor
             rect.x     = toolRightAlignedX + SEPARATOR_WIDTH;
             rect.width = COLOR_WIDTH;
 
-            EditorGUI.DrawRect(rect, group.Color);
+            EditorGUI.DrawRect(rect, group.color);
             rect.x = cursor.x;
             rect.y += rect.height;
             rect.width = cursor.width;
@@ -356,7 +356,7 @@ namespace Unity.SelectionGroups.Editor
                     switch (evt.button)
                     {
                         case RIGHT_MOUSE_BUTTON:
-                            ShowGroupContextMenu(rect, @group.Name, @group);
+                            ShowGroupContextMenu(rect, @group.groupName, @group);
                             break;
                         case LEFT_MOUSE_BUTTON:
                             m_leftMouseWasDoubleClicked = evt.clickCount > 1;
@@ -387,7 +387,7 @@ namespace Unity.SelectionGroups.Editor
                     DragAndDrop.objectReferences = new[] { @group.gameObject };
                     DragAndDrop.SetGenericData(DRAG_ITEM_TYPE,DragItemType.GROUP);
                     DragAndDrop.SetGenericData(DRAG_GROUP_INDEX,groupIndex);
-                    DragAndDrop.StartDrag(@group.Name);
+                    DragAndDrop.StartDrag(@group.groupName);
                     evt.Use();
                     break;
                 case EventType.DragUpdated: {

--- a/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.GUI.cs
+++ b/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.GUI.cs
@@ -79,7 +79,7 @@ namespace Unity.SelectionGroups.Editor
             viewRect.width = position.width-16;
             viewRect.height = CalculateHeight(m_GroupsToDraw);
             var windowRect = new Rect(0, 0, position.width, position.height);
-            scroll = GUI.BeginScrollView(windowRect, scroll, viewRect);
+            m_Scroll = GUI.BeginScrollView(windowRect, m_Scroll, viewRect);
             
             Rect cursor = new Rect(0, 0, position.width-kRightMargin, EditorGUIUtility.singleLineHeight);
             if (GUI.Button(cursor, kAddGroup)) CreateNewGroup();
@@ -92,7 +92,7 @@ namespace Unity.SelectionGroups.Editor
                 cursor.y += kGroupHeaderPadding; 
                 
                 //early out if this group yMin is below window rect (not visible).
-                if ((cursor.yMin - scroll.y) > position.height) break;
+                if ((cursor.yMin - m_Scroll.y) > position.height) break;
                 
                 cursor = DrawHeader(cursor, i);
                 if (m_GroupsToDraw[i].AreMembersShownInWindow())
@@ -119,10 +119,10 @@ namespace Unity.SelectionGroups.Editor
 
         private void SetupStyles()
         {
-            if (miniButtonStyle == null)
+            if (m_MiniButtonStyle == null)
             {
-                miniButtonStyle = EditorStyles.miniButton;
-                miniButtonStyle.padding = new RectOffset(0, 0, 0, 0); 
+                m_MiniButtonStyle = EditorStyles.miniButton;
+                m_MiniButtonStyle.padding = new RectOffset(0, 0, 0, 0); 
                 m_Label = "label";
             }
 
@@ -147,9 +147,9 @@ namespace Unity.SelectionGroups.Editor
                     continue;
                 
                 //if rect is below window, early out.
-                if (rect.yMin - scroll.y > position.height) return rect;
+                if (rect.yMin - m_Scroll.y > position.height) return rect;
                 //if rect is in window, draw.
-                if (rect.yMax - scroll.y > 0)
+                if (rect.yMax - m_Scroll.y > 0)
                     DrawGroupMember(rect, group, i);
                 rect.y += rect.height;
             }
@@ -165,7 +165,7 @@ namespace Unity.SelectionGroups.Editor
 
             bool isGroupMemberSelected = m_SelectedGroupMembers.Contains(group, g);
             if (isGroupMemberSelected)
-                EditorGUI.DrawRect(rect, SELECTION_COLOR);
+                EditorGUI.DrawRect(rect, s_SelectionColor);
             
             if (isMouseOver) 
             {
@@ -214,7 +214,7 @@ namespace Unity.SelectionGroups.Editor
             float currentViewWidth = EditorGUIUtility.currentViewWidth;
             
             //background
-            Color backgroundColor = ((SelectionGroup) group == m_activeSelectionGroup) ? Color.white * 0.6f : Color.white * 0.3f;
+            Color backgroundColor = ((SelectionGroup) group == m_ActiveSelectionGroup) ? Color.white * 0.6f : Color.white * 0.3f;
             if (isPaint) 
             {
                 rect.width = currentViewWidth - kRightMargin - kColorWidth;                
@@ -283,7 +283,7 @@ namespace Unity.SelectionGroups.Editor
                 content.tooltip = attr.description;
                 
                 rect.x = rightAlignedX - ((enabledToolCounter+1) * kToolXDiff);
-                if (GUI.Button(rect, content, miniButtonStyle))
+                if (GUI.Button(rect, content, m_MiniButtonStyle))
                 {
                     try
                     {
@@ -394,10 +394,10 @@ namespace Unity.SelectionGroups.Editor
                 case EventType.MouseDown:
                     switch (evt.button)
                     {
-                        case RIGHT_MOUSE_BUTTON:
+                        case kRightMouseButton:
                             ShowGroupContextMenu(rect, @group.groupName, @group);
                             break;
-                        case LEFT_MOUSE_BUTTON:
+                        case kLeftMouseButton:
                             m_LeftMouseWasDoubleClicked = evt.clickCount > 1;
                             if (m_LeftMouseWasDoubleClicked) 
                             {
@@ -409,7 +409,7 @@ namespace Unity.SelectionGroups.Editor
                     break;
                 case EventType.MouseUp:
                     switch (evt.button) {
-                        case LEFT_MOUSE_BUTTON:
+                        case kLeftMouseButton:
                             if (!m_LeftMouseWasDoubleClicked) 
                             {
                                 SetUnityEditorSelection(group);
@@ -421,7 +421,7 @@ namespace Unity.SelectionGroups.Editor
                     break;
                 
                 case EventType.MouseDrag:
-                    if ((SelectionGroup) m_activeSelectionGroup != group)
+                    if ((SelectionGroup) m_ActiveSelectionGroup != group)
                         break;
                     
                     DragAndDrop.PrepareStartDrag();
@@ -558,8 +558,8 @@ namespace Unity.SelectionGroups.Editor
 
             bool isControl = evt.control;
             bool isShift = evt.shift;
-            bool isRightMouseClick = evt.button == RIGHT_MOUSE_BUTTON;
-            bool isLeftMouseClick = evt.button == LEFT_MOUSE_BUTTON;
+            bool isRightMouseClick = evt.button == kRightMouseButton;
+            bool isLeftMouseClick = evt.button == kLeftMouseButton;
 
             switch (evt.type) 
             {
@@ -724,7 +724,7 @@ namespace Unity.SelectionGroups.Editor
         
         private void SetUnityEditorSelection(SelectionGroup group) 
         {
-            m_activeSelectionGroup = @group;
+            m_ActiveSelectionGroup = @group;
             Selection.objects = new Object[] { null == group ? null : group.gameObject };
         }
 

--- a/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.GUI.cs
+++ b/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.GUI.cs
@@ -426,7 +426,7 @@ namespace Unity.SelectionGroups.Editor
                     
                     DragAndDrop.PrepareStartDrag();
                     DragAndDrop.objectReferences = new[] { @group.gameObject };
-                    DragAndDrop.SetGenericData(kDragItemType,Editor.DragItemType.GROUP);
+                    DragAndDrop.SetGenericData(kDragItemType,Editor.DragItemType.Group);
                     DragAndDrop.SetGenericData(kDragGroupIndex,groupIndex);
                     DragAndDrop.StartDrag(@group.groupName);
                     evt.Use();
@@ -438,7 +438,7 @@ namespace Unity.SelectionGroups.Editor
                     DragItemType? dragItemType = DragAndDrop.GetGenericData(kDragItemType) as DragItemType?;
 
                     bool targetGroupIsAuto  = @group.IsAutoFilled();
-                    bool draggedItemIsGroup = (dragItemType == Editor.DragItemType.GROUP);
+                    bool draggedItemIsGroup = (dragItemType == Editor.DragItemType.Group);
 
                     if (draggedItemIsGroup) 
                     {
@@ -452,7 +452,7 @@ namespace Unity.SelectionGroups.Editor
                     else 
                     {
                         //moving window members to group.  
-                        bool isMovingWindowMembers = (dragItemType == Editor.DragItemType.WINDOW_GROUP_MEMBERS && evt.control);
+                        bool isMovingWindowMembers = (dragItemType == Editor.DragItemType.WindowGroupMembers && evt.control);
                         DragAndDrop.visualMode = isMovingWindowMembers
                             ? DragAndDropVisualMode.Move
                             : DragAndDropVisualMode.Copy; 
@@ -469,13 +469,13 @@ namespace Unity.SelectionGroups.Editor
 
                     DragItemType? dragItemType = DragAndDrop.GetGenericData(kDragItemType) as DragItemType?;
                     if (!dragItemType.HasValue) {
-                        dragItemType = Editor.DragItemType.GAMEOBJECTS; //receive gameObjects from outside the window
+                        dragItemType = Editor.DragItemType.GameObjects; //receive gameObjects from outside the window
                     } 
                     
                     try {
                         switch (dragItemType.Value) 
                         {
-                            case Editor.DragItemType.WINDOW_GROUP_MEMBERS: 
+                            case Editor.DragItemType.WindowGroupMembers: 
                             {
                                 if (evt.control) 
                                 {
@@ -492,13 +492,13 @@ namespace Unity.SelectionGroups.Editor
                                 
                                 break;
                             } 
-                            case Editor.DragItemType.GAMEOBJECTS: 
+                            case Editor.DragItemType.GameObjects: 
                             {
                                 RegisterUndo(@group, "Add Members");
                                 @group.Add(DragAndDrop.objectReferences);
                                 break;
                             }
-                            case Editor.DragItemType.GROUP: 
+                            case Editor.DragItemType.Group: 
                             {
                                 Object[] draggedObjects = DragAndDrop.objectReferences;
                                 if (null == draggedObjects || draggedObjects.Length <= 0 || null == draggedObjects[0])
@@ -637,7 +637,7 @@ namespace Unity.SelectionGroups.Editor
                     
                     DragAndDrop.PrepareStartDrag();
                     DragAndDrop.objectReferences = objects;
-                    DragAndDrop.SetGenericData(kDragItemType,Editor.DragItemType.WINDOW_GROUP_MEMBERS);
+                    DragAndDrop.SetGenericData(kDragItemType,Editor.DragItemType.WindowGroupMembers);
                     string dragText = numDraggedObjects > 1 ? objects[0].name + " ..." : objects[0].name;
                     DragAndDrop.StartDrag(dragText);
                     evt.Use();

--- a/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.GUI.cs
+++ b/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.GUI.cs
@@ -239,7 +239,7 @@ namespace Unity.SelectionGroups.Editor
             Rect rect = new Rect(0, y, TOOL_X_DIFF, TOOL_HEIGHT); 
             int enabledToolCounter = 0;
             
-            for (int toolId = (int)SelectionGroupToolType.BUILT_IN_MAX-1; toolId >=0; --toolId) {
+            for (int toolId = (int)SelectionGroupToolType.BuiltInMAX-1; toolId >=0; --toolId) {
                 bool toolStatus = group.GetEditorToolState(toolId);
                 if (false == toolStatus)
                     continue;

--- a/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.Messages.cs
+++ b/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.Messages.cs
@@ -51,9 +51,9 @@ namespace Unity.SelectionGroups.Editor
                     case EventType.KeyDown: {
                         if (Event.current.keyCode == (KeyCode.Delete)) 
                         {
-                            if (null != m_activeSelectionGroup) 
+                            if (null != m_ActiveSelectionGroup) 
                             {
-                                DeleteGroup(m_activeSelectionGroup);
+                                DeleteGroup(m_ActiveSelectionGroup);
                             } 
                             else 
                             {

--- a/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.Messages.cs
+++ b/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.Messages.cs
@@ -12,11 +12,9 @@ using Object = UnityEngine.Object;
 
 namespace Unity.SelectionGroups.Editor
 {
-
     internal partial class SelectionGroupEditorWindow : EditorWindow
     {
-
-        void OnEnable()
+        private void OnEnable()
         {
             titleContent.text = "Selection Groups";
             wantsMouseMove = true;
@@ -25,12 +23,12 @@ namespace Unity.SelectionGroups.Editor
             Undo.undoRedoPerformed += OnUndoRedoPerformed;
         }
 
-        private void OnDisable() {
+        private void OnDisable() 
+        {
             Undo.undoRedoPerformed -= OnUndoRedoPerformed;
         }
 
-
-        void OnGUI()
+        private void OnGUI()
         {
             try
             {
@@ -51,10 +49,14 @@ namespace Unity.SelectionGroups.Editor
                         OnExecuteCommand(Event.current);
                         break;
                     case EventType.KeyDown: {
-                        if (Event.current.keyCode == (KeyCode.Delete)) {
-                            if (null != m_activeSelectionGroup) {
+                        if (Event.current.keyCode == (KeyCode.Delete)) 
+                        {
+                            if (null != m_activeSelectionGroup) 
+                            {
                                 DeleteGroup(m_activeSelectionGroup);
-                            } else {
+                            } 
+                            else 
+                            {
                                 RemoveSelectedMembersFromGroup();  
                             }
                             evt.Use();
@@ -67,15 +69,15 @@ namespace Unity.SelectionGroups.Editor
             {
                 Profiler.EndSample();
             }
-
-            
         }
 
-        void OnExecuteCommand(Event current)
+        private void OnExecuteCommand(Event current)
         {
-            switch (current.commandName) {
+            switch (current.commandName) 
+            {
                 case "SelectAll":
-                    foreach (SelectionGroup group in SelectionGroupManager.GetOrCreateInstance().groups) {
+                    foreach (SelectionGroup group in SelectionGroupManager.GetOrCreateInstance().groups) 
+                    {
                         m_selectedGroupMembers.AddGroupMembers(group);
                     }
                     UpdateUnityEditorSelectionWithMembers();
@@ -89,8 +91,10 @@ namespace Unity.SelectionGroups.Editor
                     GroupMembersSelection prevSelectedMembers = new GroupMembersSelection(m_selectedGroupMembers);
                     m_selectedGroupMembers.Clear();
                     
-                    foreach (SelectionGroup group in SelectionGroupManager.GetOrCreateInstance().groups) {
-                        foreach (Object m in group.Members) {
+                    foreach (SelectionGroup group in SelectionGroupManager.GetOrCreateInstance().groups) 
+                    {
+                        foreach (Object m in group.Members) 
+                        {
                             if (prevSelectedMembers.Contains(group, m))
                                 continue;
                             m_selectedGroupMembers.AddObject(group,m);
@@ -101,7 +105,7 @@ namespace Unity.SelectionGroups.Editor
             }
         }
 
-        void OnValidateCommand(Event current)
+        private void OnValidateCommand(Event current)
         {
             switch (current.commandName)
             {
@@ -117,9 +121,9 @@ namespace Unity.SelectionGroups.Editor
             }
         }
         
-        private void OnUndoRedoPerformed() {
+        private void OnUndoRedoPerformed() 
+        {
             Repaint();
         }
-        
     }
 }

--- a/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.Messages.cs
+++ b/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.Messages.cs
@@ -19,7 +19,7 @@ namespace Unity.SelectionGroups.Editor
             titleContent.text = "Selection Groups";
             wantsMouseMove = true;
             
-            sceneHeaderContent     =  EditorGUIUtility.IconContent("SceneAsset Icon");
+            m_SceneHeaderContent     =  EditorGUIUtility.IconContent("SceneAsset Icon");
             Undo.undoRedoPerformed += OnUndoRedoPerformed;
         }
 
@@ -78,7 +78,7 @@ namespace Unity.SelectionGroups.Editor
                 case "SelectAll":
                     foreach (SelectionGroup group in SelectionGroupManager.GetOrCreateInstance().groups) 
                     {
-                        m_selectedGroupMembers.AddGroupMembers(group);
+                        m_SelectedGroupMembers.AddGroupMembers(group);
                     }
                     UpdateUnityEditorSelectionWithMembers();
                     current.Use();
@@ -88,8 +88,8 @@ namespace Unity.SelectionGroups.Editor
                     current.Use();
                     break;
                 case "InvertSelection":
-                    GroupMembersSelection prevSelectedMembers = new GroupMembersSelection(m_selectedGroupMembers);
-                    m_selectedGroupMembers.Clear();
+                    GroupMembersSelection prevSelectedMembers = new GroupMembersSelection(m_SelectedGroupMembers);
+                    m_SelectedGroupMembers.Clear();
                     
                     foreach (SelectionGroup group in SelectionGroupManager.GetOrCreateInstance().groups) 
                     {
@@ -97,7 +97,7 @@ namespace Unity.SelectionGroups.Editor
                         {
                             if (prevSelectedMembers.Contains(group, m))
                                 continue;
-                            m_selectedGroupMembers.AddObject(group,m);
+                            m_SelectedGroupMembers.AddObject(group,m);
                         }
                     }
                     current.Use();

--- a/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.Messages.cs
+++ b/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.Messages.cs
@@ -75,7 +75,7 @@ namespace Unity.SelectionGroups.Editor
         {
             switch (current.commandName) {
                 case "SelectAll":
-                    foreach (SelectionGroup group in SelectionGroupManager.GetOrCreateInstance().Groups) {
+                    foreach (SelectionGroup group in SelectionGroupManager.GetOrCreateInstance().groups) {
                         m_selectedGroupMembers.AddGroupMembers(group);
                     }
                     UpdateUnityEditorSelectionWithMembers();
@@ -89,7 +89,7 @@ namespace Unity.SelectionGroups.Editor
                     GroupMembersSelection prevSelectedMembers = new GroupMembersSelection(m_selectedGroupMembers);
                     m_selectedGroupMembers.Clear();
                     
-                    foreach (SelectionGroup group in SelectionGroupManager.GetOrCreateInstance().Groups) {
+                    foreach (SelectionGroup group in SelectionGroupManager.GetOrCreateInstance().groups) {
                         foreach (Object m in group.Members) {
                             if (prevSelectedMembers.Contains(group, m))
                                 continue;

--- a/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.cs
+++ b/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.cs
@@ -8,50 +8,47 @@ namespace Unity.SelectionGroups.Editor
     /// <summary>
     /// The main editor window for working with selection groups.
     /// </summary>
-    
     internal partial class SelectionGroupEditorWindow : EditorWindow
     {
+        private const int kLeftMouseButton = 0;
+        private const int kRightMouseButton = 1;
 
-        const int LEFT_MOUSE_BUTTON = 0;
-        const int RIGHT_MOUSE_BUTTON = 1;
+        private static readonly Color s_SelectionColor = new Color32(62, 95, 150, 255);
+        private static float? s_PerformQueryRefresh = null;
 
-        static readonly Color SELECTION_COLOR = new Color32(62, 95, 150, 255);
+        private ReorderableList m_List;
+        private Vector2 m_Scroll;
+        private SelectionGroup m_ActiveSelectionGroup;
+        private float m_Width;
+        private GUIStyle m_MiniButtonStyle;
+        private Object m_HotMember;
 
-        ReorderableList list;
-        Vector2 scroll;
-        SelectionGroup m_activeSelectionGroup;
-        float width;
-        GUIStyle miniButtonStyle;
-        Object hotMember;
-
-        private static float? performQueryRefresh = null;
-
-        
         [InitializeOnLoadMethod]
-        static void SetupQueryCallbacks()
+        private static void SetupQueryCallbacks()
         {
             EditorApplication.hierarchyChanged -= OnHierarchyChanged;
             EditorApplication.hierarchyChanged += OnHierarchyChanged;
         }
 
-        void Update()
+        private void Update()
         {
             //This should coalesce many consecutive and possibly duplicate or spurious
             //hierarchy change events into a single query update and repaint operation.
-            if (performQueryRefresh.HasValue && EditorApplication.timeSinceStartup > performQueryRefresh.Value)
+            if (s_PerformQueryRefresh.HasValue && EditorApplication.timeSinceStartup > s_PerformQueryRefresh.Value)
             {
                 SelectionGroupManager.UpdateQueryResults();
-                performQueryRefresh = null;
+                s_PerformQueryRefresh = null;
                 Repaint();
             }
         }
         
         private static void OnHierarchyChanged()
         {
-            performQueryRefresh = (float) (EditorApplication.timeSinceStartup + 0.2f);
+            s_PerformQueryRefresh = (float) (EditorApplication.timeSinceStartup + 0.2f);
         }
 
-        static void CreateNewGroup() {
+        private static void CreateNewGroup() 
+        {
             SelectionGroupManager sgManager = SelectionGroupManager.GetOrCreateInstance();
             
             int numGroups = sgManager.groups.Count;
@@ -59,7 +56,7 @@ namespace Unity.SelectionGroups.Editor
                 Color.HSVToRGB(Random.value, Random.Range(0.9f, 1f), Random.Range(0.9f, 1f)));
         }
 
-        static void RegisterUndo(SelectionGroup group, string msg)
+        private static void RegisterUndo(SelectionGroup group, string msg)
         {
             Undo.RegisterCompleteObjectUndo(group, msg);
             EditorUtility.SetDirty(group);

--- a/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.cs
+++ b/Editor/Scripts/SelectionGroupWindow/SelectionGroupEditorWindow.cs
@@ -54,7 +54,7 @@ namespace Unity.SelectionGroups.Editor
         static void CreateNewGroup() {
             SelectionGroupManager sgManager = SelectionGroupManager.GetOrCreateInstance();
             
-            int numGroups = sgManager.Groups.Count;
+            int numGroups = sgManager.groups.Count;
             sgManager.CreateSelectionGroup($"SG_New Group {numGroups}",
                 Color.HSVToRGB(Random.value, Random.Range(0.9f, 1f), Random.Range(0.9f, 1f)));
         }

--- a/Editor/Scripts/Tools/SelectionGroupToolAttributeCache.cs
+++ b/Editor/Scripts/Tools/SelectionGroupToolAttributeCache.cs
@@ -5,39 +5,35 @@ using UnityEditor;
 
 namespace Unity.SelectionGroups.Editor
 {
-internal static class SelectionGroupToolAttributeCache {
+    internal static class SelectionGroupToolAttributeCache 
+    {
+        private static readonly TypeCache.MethodCollection m_ToolMethods = TypeCache.GetMethodsWithAttribute<SelectionGroupToolAttribute>();        
 
-    [InitializeOnLoadMethod]
-    static void SelectionGroupToolAttributeCache_OnLoad() {
+        private static readonly Dictionary<int, SelectionGroupToolAttribute> m_ToolAttributeMap = new Dictionary<int, SelectionGroupToolAttribute>();
+        private static readonly Dictionary<int, MethodInfo> m_ToolMethodInfoMap = new Dictionary<int, MethodInfo>();
+
+        [InitializeOnLoadMethod]
+        private static void SelectionGroupToolAttributeCache_OnLoad() 
+        {
+            m_ToolAttributeMap.Clear();
+
+            foreach (MethodInfo methodInfo in m_ToolMethods) 
+            {
+                SelectionGroupToolAttribute attr = methodInfo.GetCustomAttribute<SelectionGroupToolAttribute>();
+                m_ToolMethodInfoMap[attr.toolId] = methodInfo;
+                m_ToolAttributeMap[attr.toolId]  = attr;            
+            }
+        }
         
-        m_toolAttributeMap.Clear();
+        internal static bool TryGetAttribute(int id, out SelectionGroupToolAttribute attribute) 
+        {
+            return m_ToolAttributeMap.TryGetValue(id, out attribute);            
+        }
 
-        foreach (MethodInfo methodInfo in m_toolMethods) {
-            SelectionGroupToolAttribute attr = methodInfo.GetCustomAttribute<SelectionGroupToolAttribute>();
-            m_toolMethodInfoMap[attr.toolId] = methodInfo;
-            m_toolAttributeMap[attr.toolId]  = attr;            
+        internal static bool TryGetMethodInfo(int id, out MethodInfo methodInfo) 
+        {
+            return m_ToolMethodInfoMap.TryGetValue(id, out methodInfo);            
         }
     }
-    
-//----------------------------------------------------------------------------------------------------------------------
-
-    internal static bool TryGetAttribute(int id, out SelectionGroupToolAttribute attribute) {
-        return m_toolAttributeMap.TryGetValue(id, out attribute);            
-    }
-
-    internal static bool TryGetMethodInfo(int id, out MethodInfo methodInfo) {
-        return m_toolMethodInfoMap.TryGetValue(id, out methodInfo);            
-    }
-    
-
-//----------------------------------------------------------------------------------------------------------------------
-    
-    private static readonly TypeCache.MethodCollection m_toolMethods = TypeCache.GetMethodsWithAttribute<SelectionGroupToolAttribute>();        
-
-    private static readonly Dictionary<int, SelectionGroupToolAttribute> m_toolAttributeMap = new Dictionary<int, SelectionGroupToolAttribute>();
-    private static readonly Dictionary<int, MethodInfo> m_toolMethodInfoMap = new Dictionary<int, MethodInfo>();
-    
 
 }
-
-} //end namespace

--- a/Editor/Scripts/Tools/SelectionGroupTools.cs
+++ b/Editor/Scripts/Tools/SelectionGroupTools.cs
@@ -11,7 +11,7 @@ namespace Unity.SelectionGroups.Editor
     public static class SelectionGroupTools
     {
         [SelectionGroupTool("d_VisibilityOn", "Show or hide objects in the scene.",(int) SelectionGroupToolType.Visibility)]
-        static void ToggleVisibility(SelectionGroup group) 
+        private static void ToggleVisibility(SelectionGroup group) 
         {
             List<GameObject> goMembers = group.FindGameObjectMembers();
             if (goMembers.Count <= 0)
@@ -19,15 +19,18 @@ namespace Unity.SelectionGroups.Editor
 
             SceneVisibilityManager sceneVisibilityManager = SceneVisibilityManager.instance;
             bool show = (sceneVisibilityManager.IsHidden(goMembers[0]));
-            if (show) {
+            if (show) 
+            {
                 sceneVisibilityManager.Show(goMembers.ToArray(), false);
-            } else {
+            } 
+            else
+            {
                 sceneVisibilityManager.Hide(goMembers.ToArray(), false);
             }
         }
 
         [SelectionGroupTool("LockIcon-On", "Enable or disable editing of objects.",(int) SelectionGroupToolType.Lock)]
-        static void ToggleLock(SelectionGroup group) 
+        private static void ToggleLock(SelectionGroup group) 
         {
             IList<Object> members  = group.Members;
             if (null == members || members.Count <= 0)
@@ -45,6 +48,5 @@ namespace Unity.SelectionGroups.Editor
                     obj.hideFlags |= HideFlags.NotEditable;
             }
         }
-
     }
 }

--- a/Editor/Scripts/Tools/SelectionGroupTools.cs
+++ b/Editor/Scripts/Tools/SelectionGroupTools.cs
@@ -10,7 +10,7 @@ namespace Unity.SelectionGroups.Editor
     /// </summary>
     public static class SelectionGroupTools
     {
-        [SelectionGroupTool("d_VisibilityOn", "Show or hide objects in the scene.",(int) SelectionGroupToolType.VISIBILITY)]
+        [SelectionGroupTool("d_VisibilityOn", "Show or hide objects in the scene.",(int) SelectionGroupToolType.Visibility)]
         static void ToggleVisibility(SelectionGroup group) 
         {
             List<GameObject> goMembers = group.FindGameObjectMembers();
@@ -26,7 +26,7 @@ namespace Unity.SelectionGroups.Editor
             }
         }
 
-        [SelectionGroupTool("LockIcon-On", "Enable or disable editing of objects.",(int) SelectionGroupToolType.LOCK)]
+        [SelectionGroupTool("LockIcon-On", "Enable or disable editing of objects.",(int) SelectionGroupToolType.Lock)]
         static void ToggleLock(SelectionGroup group) 
         {
             IList<Object> members  = group.Members;

--- a/Runtime/Scripts/EditorToolStates.cs
+++ b/Runtime/Scripts/EditorToolStates.cs
@@ -1,9 +1,9 @@
 using System;
 using Unity.FilmInternalUtilities;
 
-namespace Unity.SelectionGroups {
-
-[Serializable]
-internal class EditorToolStates : SerializedDictionary<int, bool> {}
+namespace Unity.SelectionGroups 
+{
+    [Serializable]
+    internal class EditorToolStates : SerializedDictionary<int, bool> {}
 
 } //end namespace

--- a/Runtime/Scripts/GroupMembersSelection.cs
+++ b/Runtime/Scripts/GroupMembersSelection.cs
@@ -4,120 +4,134 @@ using Object = UnityEngine.Object;
 
 namespace Unity.SelectionGroups
 {
+    //A class to hold selected members from selected groups
+    internal class GroupMembersSelection : IEnumerable<KeyValuePair<SelectionGroup, OrderedSet<Object>>>
+    {
+        private readonly Dictionary<SelectionGroup, OrderedSet<Object>> m_SelectedGroupMembers 
+            = new Dictionary<SelectionGroup, OrderedSet<Object>>();
+        
+        internal GroupMembersSelection() { }
 
-//A class to hold selected members from selected groups
-internal class GroupMembersSelection : IEnumerable<KeyValuePair<SelectionGroup, OrderedSet<Object>>>
-{
+        internal GroupMembersSelection(GroupMembersSelection other) 
+        {
+            foreach (KeyValuePair<SelectionGroup, OrderedSet<Object>> kv in other) 
+            {
+                OrderedSet<Object> collection = new OrderedSet<Object>() { };
+                foreach (Object member in kv.Value) 
+                {
+                    collection.Add(member);
+                }
 
-    internal GroupMembersSelection() { }
+                m_SelectedGroupMembers[kv.Key] = collection;
+            }
+        }
+    //----------------------------------------------------------------------------------------------------------------------
+        
+        public IEnumerator<KeyValuePair<SelectionGroup, OrderedSet<Object>>> GetEnumerator() 
+        {
+            return m_SelectedGroupMembers.GetEnumerator();
+        }
 
-    internal GroupMembersSelection(GroupMembersSelection other) {
-
-        foreach (KeyValuePair<SelectionGroup, OrderedSet<Object>> kv in other) {
-            OrderedSet<Object> collection = new OrderedSet<Object>() { };
-            foreach (Object member in kv.Value) {
-                collection.Add(member);
+        IEnumerator IEnumerable.GetEnumerator() 
+        {
+            return this.GetEnumerator();
+        }
+        
+    //----------------------------------------------------------------------------------------------------------------------
+        
+        internal void AddObject(SelectionGroup group, Object member) 
+        {
+            if (!m_SelectedGroupMembers.ContainsKey(group)) 
+            {
+                m_SelectedGroupMembers.Add(group, new OrderedSet<Object>(){member});
+                return;
             }
 
-            m_selectedGroupMembers[kv.Key] = collection;
-        }
-    }
-//----------------------------------------------------------------------------------------------------------------------
-    
-    public IEnumerator<KeyValuePair<SelectionGroup, OrderedSet<Object>>> GetEnumerator() {
-        return m_selectedGroupMembers.GetEnumerator();
-    }
-
-    IEnumerator IEnumerable.GetEnumerator() {
-        return this.GetEnumerator();
-    }
-    
-//----------------------------------------------------------------------------------------------------------------------
-    
-    internal void AddObject(SelectionGroup group, Object member) {
-        if (!m_selectedGroupMembers.ContainsKey(group)) {
-            m_selectedGroupMembers.Add(group, new OrderedSet<Object>(){member});
-            return;
+            m_SelectedGroupMembers[group].Add(member);
         }
 
-        m_selectedGroupMembers[group].Add(member);
-    }
-
-    internal void AddGroupMembers(SelectionGroup group) {
-        AddObjects(group, group.Members);
-    }
-    
-    
-    internal void Add(GroupMembersSelection otherSelection) {
-        foreach (KeyValuePair<SelectionGroup, OrderedSet<Object>> kv in otherSelection) {
-            SelectionGroup group = kv.Key;
-            AddObjects(group, kv.Value);
-        }
-    }
-    
-
-    private void AddObjects(SelectionGroup group, IEnumerable<Object> objects) {
-        
-        OrderedSet<Object> collection = null;
-        if (!m_selectedGroupMembers.ContainsKey(group)) {
-            collection = new OrderedSet<Object>() { };
-            m_selectedGroupMembers.Add(group, collection);
-        } else {
-            collection = m_selectedGroupMembers[group];
+        internal void AddGroupMembers(SelectionGroup group) 
+        {
+            AddObjects(group, group.Members);
         }
 
-        foreach (Object m in objects) {
-            collection.Add(m);
+        internal void Add(GroupMembersSelection otherSelection) 
+        {
+            foreach (KeyValuePair<SelectionGroup, OrderedSet<Object>> kv in otherSelection) 
+            {
+                SelectionGroup group = kv.Key;
+                AddObjects(group, kv.Value);
+            }
         }
         
-    }
-    
+        private void AddObjects(SelectionGroup group, IEnumerable<Object> objects) 
+        {
+            
+            OrderedSet<Object> collection = null;
+            if (!m_SelectedGroupMembers.ContainsKey(group)) 
+            {
+                collection = new OrderedSet<Object>() { };
+                m_SelectedGroupMembers.Add(group, collection);
+            } else 
+            {
+                collection = m_SelectedGroupMembers[group];
+            }
 
-    internal void RemoveObject(SelectionGroup group, Object member) {
-        if (!m_selectedGroupMembers.ContainsKey(group)) {
-            return;
+            foreach (Object m in objects) {
+                collection.Add(m);
+            }
+            
         }
 
-        m_selectedGroupMembers[group].Remove(member);
-    }
+        internal void RemoveObject(SelectionGroup group, Object member) 
+        {
+            if (!m_SelectedGroupMembers.ContainsKey(group))
+            {
+                return;
+            }
 
-    internal void RemoveGroup(SelectionGroup group) {
-        if (!m_selectedGroupMembers.ContainsKey(group)) {
-            return;
+            m_SelectedGroupMembers[group].Remove(member);
         }
-        m_selectedGroupMembers.Remove(group);
-    }
-    
-    internal bool Contains(SelectionGroup group, Object member) {
-        if (!m_selectedGroupMembers.ContainsKey(group))
-            return false;
 
-        return (m_selectedGroupMembers[group].Contains(member));
-    }
+        internal void RemoveGroup(SelectionGroup group) 
+        {
+            if (!m_SelectedGroupMembers.ContainsKey(group)) 
+            {
+                return;
+            }
+            m_SelectedGroupMembers.Remove(group);
+        }
         
-    internal void Clear() {
-        m_selectedGroupMembers.Clear();
-    }
+        internal bool Contains(SelectionGroup group, Object member) 
+        {
+            if (!m_SelectedGroupMembers.ContainsKey(group))
+                return false;
 
-    internal Object[] ConvertMembersToArray() {
-        HashSet<Object> set = ConvertMembersToSet();
-        Object[] arr = new Object[set.Count];
-        set.CopyTo(arr);
-        return arr;
-    }
-
-    internal HashSet<Object> ConvertMembersToSet() {
-        HashSet<Object> set = new HashSet<Object>();
-        foreach (KeyValuePair<SelectionGroup, OrderedSet<Object>> kv in m_selectedGroupMembers) {
-            set.UnionWith(kv.Value);
+            return (m_SelectedGroupMembers[group].Contains(member));
+        }
+            
+        internal void Clear() 
+        {
+            m_SelectedGroupMembers.Clear();
         }
 
-        return set;
+        internal Object[] ConvertMembersToArray() 
+        {
+            HashSet<Object> set = ConvertMembersToSet();
+            Object[] arr = new Object[set.Count];
+            set.CopyTo(arr);
+            return arr;
+        }
+
+        internal HashSet<Object> ConvertMembersToSet() 
+        {
+            HashSet<Object> set = new HashSet<Object>();
+            foreach (KeyValuePair<SelectionGroup, OrderedSet<Object>> kv in m_SelectedGroupMembers)
+            {
+                set.UnionWith(kv.Value);
+            }
+
+            return set;
+        }
     }
-    
-//----------------------------------------------------------------------------------------------------------------------    
-    readonly Dictionary<SelectionGroup, OrderedSet<Object>> m_selectedGroupMembers 
-        = new Dictionary<SelectionGroup, OrderedSet<Object>>();
-    
-}
 } //end namespace

--- a/Runtime/Scripts/SelectionGroupConstants.cs
+++ b/Runtime/Scripts/SelectionGroupConstants.cs
@@ -1,7 +1,8 @@
-namespace Unity.SelectionGroups {
-
-internal static class SelectionGroupConstants {
-    internal const string PACKAGES_PATH = "Packages/com.unity.selection-groups";    
-}
+namespace Unity.SelectionGroups 
+{
+    internal static class SelectionGroupConstants 
+    {
+        internal const string PackagesPath = "Packages/com.unity.selection-groups";    
+    }
 
 } //end namespace

--- a/Runtime/Scripts/SelectionGroupManager.cs
+++ b/Runtime/Scripts/SelectionGroupManager.cs
@@ -108,7 +108,7 @@ namespace Unity.SelectionGroups
             group.color       = color;
             
             SelectionGroupsEditorProjectSettings projSettings = SelectionGroupsEditorProjectSettings.GetOrCreateInstance();
-            for (int i = 0; i < (int)SelectionGroupToolType.BUILT_IN_MAX; ++i) 
+            for (int i = 0; i < (int)SelectionGroupToolType.BuiltInMAX; ++i) 
             {
                 group.EnableEditorTool(i, projSettings.GetDefaultGroupEditorToolState(i));
             }

--- a/Runtime/Scripts/SelectionGroupManager.cs
+++ b/Runtime/Scripts/SelectionGroupManager.cs
@@ -4,161 +4,179 @@ using System.Linq;
 using Unity.FilmInternalUtilities;
 using UnityEngine;
 using UnityEngine.Assertions;
+using UnityEngine.Serialization;
 using Object = UnityEngine.Object;
 
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
 
-namespace Unity.SelectionGroups {
+namespace Unity.SelectionGroups 
+{
+    [ExecuteAlways]
+    [AddComponentMenu("")]
+    internal class SelectionGroupManager : MonoBehaviourSingleton<SelectionGroupManager>, ISerializationCallbackReceiver 
+    {
+        [FormerlySerializedAs("m_sceneSelectionGroups")] 
+        [SerializeField] private List<SelectionGroup> m_SceneSelectionGroups = new List<SelectionGroup>();
+        
+        internal IList<SelectionGroup> groups => m_SceneSelectionGroups;
 
-[ExecuteAlways]
-[AddComponentMenu("")]
-internal class SelectionGroupManager : MonoBehaviourSingleton<SelectionGroupManager>, ISerializationCallbackReceiver {
-    private void OnEnable() {
-        this.gameObject.hideFlags = HideFlags.HideInHierarchy;
-    }
+        internal IEnumerable<string> groupNames => m_SceneSelectionGroups.Select(g => g.groupName);
+        
+        private void OnEnable() 
+        {
+            gameObject.hideFlags = HideFlags.HideInHierarchy;
+        }
 
-
-    public static void UpdateQueryResults() {
-        foreach (var i in SelectionGroupManager.GetOrCreateInstance().m_sceneSelectionGroups) {
-            if (!string.IsNullOrEmpty(i.query)) {
-                i.UpdateQueryResults();
+        public static void UpdateQueryResults() 
+        {
+            foreach (var i in SelectionGroupManager.GetOrCreateInstance().m_SceneSelectionGroups) 
+            {
+                if (!string.IsNullOrEmpty(i.query)) 
+                {
+                    i.UpdateQueryResults();
+                }
             }
         }
-    }
 
-    internal IList<SelectionGroup> Groups => m_sceneSelectionGroups;
+        [Obsolete]
+        internal SelectionGroup CreateSceneSelectionGroup(string groupName, string query, Color color, IList<Object> members) 
+        {
+            SelectionGroup group = CreateSelectionGroupInternal(groupName, color);        
+            group.SetQuery(query);
 
-    internal IEnumerable<string> GroupNames => m_sceneSelectionGroups.Select(g => g.groupName);
+            if (!group.IsAutoFilled()) 
+            {
+                group.Add(members);
+            }
 
+            m_SceneSelectionGroups.Add(group);
+            return group;
+        }
 
-    [Obsolete]
-    internal SelectionGroup CreateSceneSelectionGroup(string groupName, string query, Color color, IList<Object> members) {
-        SelectionGroup group = CreateSelectionGroupInternal(groupName, color);        
-        group.SetQuery(query);
+        [Obsolete]
+        internal SelectionGroup CreateSceneSelectionGroup(string groupName, Color color) 
+        {
+            return CreateSelectionGroup(groupName, color);
+        }
+        
+        [Obsolete]
+        internal SelectionGroup CreateSceneSelectionGroup(string groupName, Color color, string query) 
+        {
+            return CreateSelectionGroup(groupName, color, query);
+        }
 
-        if (!group.IsAutoFilled()) {
+        [Obsolete]
+        internal SelectionGroup CreateSceneSelectionGroup(string groupName, Color color, IList<Object> members) 
+        {
+            return CreateSelectionGroup(groupName, color, members);
+        }
+
+        //
+        internal SelectionGroup CreateSelectionGroup(string groupName, Color color) 
+        {
+            SelectionGroup group = CreateSelectionGroupInternal(groupName, color);
+            m_SceneSelectionGroups.Add(group);
+            return group;
+        }
+        
+        internal SelectionGroup CreateSelectionGroup(string groupName, Color color, string query)
+        {
+            SelectionGroup group = CreateSelectionGroupInternal(groupName, color);        
+            group.SetQuery(query);
+            m_SceneSelectionGroups.Add(group);
+            return group;
+        }
+
+        internal SelectionGroup CreateSelectionGroup(string groupName, Color color, IList<Object> members)
+        {
+            SelectionGroup group = CreateSelectionGroupInternal(groupName, color);
             group.Add(members);
+            m_SceneSelectionGroups.Add(group);
+            return group;
         }
 
-        m_sceneSelectionGroups.Add(group);
-        return group;
-    }
-
-    [Obsolete]
-    internal SelectionGroup CreateSceneSelectionGroup(string groupName, Color color) {
-        return CreateSelectionGroup(groupName, color);
-    }
-    
-    [Obsolete]
-    internal SelectionGroup CreateSceneSelectionGroup(string groupName, Color color, string query) {
-        return CreateSelectionGroup(groupName, color, query);
-    }
-
-    [Obsolete]
-    internal SelectionGroup CreateSceneSelectionGroup(string groupName, Color color, IList<Object> members) {
-        return CreateSelectionGroup(groupName, color, members);
-    }
-    
-
-    //
-    internal SelectionGroup CreateSelectionGroup(string groupName, Color color) {
-        SelectionGroup group = CreateSelectionGroupInternal(groupName, color);
-        m_sceneSelectionGroups.Add(group);
-        return group;
-    }
-    
-    internal SelectionGroup CreateSelectionGroup(string groupName, Color color, string query) {
-        SelectionGroup group = CreateSelectionGroupInternal(groupName, color);        
-        group.SetQuery(query);
-        m_sceneSelectionGroups.Add(group);
-        return group;
-    }
-
-    internal SelectionGroup CreateSelectionGroup(string groupName, Color color, IList<Object> members) {
-        SelectionGroup group = CreateSelectionGroupInternal(groupName, color);
-        group.Add(members);
-        m_sceneSelectionGroups.Add(group);
-        return group;
-    }
-
-    private static SelectionGroup CreateSelectionGroupInternal(string groupName, Color color) {
-        GameObject g = new GameObject(groupName);
-#if UNITY_EDITOR
-        Undo.RegisterCreatedObjectUndo(g, "New Scene Selection Group");
-#endif
-        SelectionGroup group = g.AddComponent<SelectionGroup>();
-        group.groupName        = groupName;
-        group.color       = color;
-        
-        SelectionGroupsEditorProjectSettings projSettings = SelectionGroupsEditorProjectSettings.GetOrCreateInstance();
-        for (int i = 0; i < (int)SelectionGroupToolType.BUILT_IN_MAX; ++i) {
-            group.EnableEditorTool(i, projSettings.GetDefaultGroupEditorToolState(i));
-        }
-        
-        return group;
-    }
-
-//----------------------------------------------------------------------------------------------------------------------
-    
-    internal void ClearGroups() {
-        int numGroups = m_sceneSelectionGroups.Count;
-        for (int i = numGroups - 1; i >= 0; --i) {
-            SelectionGroup g = m_sceneSelectionGroups[i];
-            if (null == g)
-                continue;
+        private static SelectionGroup CreateSelectionGroupInternal(string groupName, Color color)
+        {
+            GameObject g = new GameObject(groupName);
+    #if UNITY_EDITOR
+            Undo.RegisterCreatedObjectUndo(g, "New Scene Selection Group");
+    #endif
+            SelectionGroup group = g.AddComponent<SelectionGroup>();
+            group.groupName        = groupName;
+            group.color       = color;
             
-            FilmInternalUtilities.ObjectUtility.Destroy(g.gameObject, forceImmediate: true);
+            SelectionGroupsEditorProjectSettings projSettings = SelectionGroupsEditorProjectSettings.GetOrCreateInstance();
+            for (int i = 0; i < (int)SelectionGroupToolType.BUILT_IN_MAX; ++i) 
+            {
+                group.EnableEditorTool(i, projSettings.GetDefaultGroupEditorToolState(i));
+            }
+            
+            return group;
         }
-        m_sceneSelectionGroups.Clear();
-    }
+
+        //----------------------------------------------------------------------------------------------------------------------
         
-    
-    
-    internal void DeleteGroup(SelectionGroup group) {
+        internal void ClearGroups() 
+        {
+            int numGroups = m_SceneSelectionGroups.Count;
+            for (int i = numGroups - 1; i >= 0; --i) 
+            {
+                SelectionGroup g = m_SceneSelectionGroups[i];
+                if (null == g)
+                    continue;
+                
+                FilmInternalUtilities.ObjectUtility.Destroy(g.gameObject, forceImmediate: true);
+            }
+            m_SceneSelectionGroups.Clear();
+        }
+
+        internal void DeleteGroup(SelectionGroup group) 
+        {
+            
+    #if UNITY_EDITOR
+            Undo.RegisterCompleteObjectUndo(this, "Delete Group");
+            Undo.DestroyObjectImmediate(group.gameObject);
+    #else
+            DestroyImmediate(group,gameObject);
+    #endif
+            m_SceneSelectionGroups.Remove(group);
+        }
         
-#if UNITY_EDITOR
-        Undo.RegisterCompleteObjectUndo(this, "Delete Group");
-        Undo.DestroyObjectImmediate(group.gameObject);
-#else
-        DestroyImmediate(group,gameObject);
-#endif
-        m_sceneSelectionGroups.Remove(group);
+        //----------------------------------------------------------------------------------------------------------------------
+
+        internal void Register(SelectionGroup group) 
+        {
+            Assert.IsNotNull(group);
+            m_SceneSelectionGroups.Add(group);
+        }
+
+        internal void Unregister(SelectionGroup group) 
+        {
+            m_SceneSelectionGroups.Remove(group);
+        }
+        
+        internal void MoveGroup(int prevIndex, int newIndex) 
+        {
+    #if UNITY_EDITOR
+            Undo.RegisterCompleteObjectUndo(this, "Move Group");
+    #endif
+            m_SceneSelectionGroups.Move(prevIndex, newIndex);
+        }
+
+        //----------------------------------------------------------------------------------------------------------------------
+
+        ///<inheritdoc/>
+        public void OnBeforeSerialize() 
+        {
+            m_SceneSelectionGroups.RemoveAll((g) => null == g);
+        }
+
+        ///<inheritdoc/>
+        public void OnAfterDeserialize() { }
+        
+        //----------------------------------------------------------------------------------------------------------------------
+
     }
-    
-//----------------------------------------------------------------------------------------------------------------------
-
-    internal void Register(SelectionGroup group) {
-        Assert.IsNotNull(group);
-        m_sceneSelectionGroups.Add(group);
-    }
-
-    internal void Unregister(SelectionGroup group) {
-        m_sceneSelectionGroups.Remove(group);
-    }
-    
-
-    internal void MoveGroup(int prevIndex, int newIndex) {
-#if UNITY_EDITOR
-        Undo.RegisterCompleteObjectUndo(this, "Move Group");
-#endif
-        m_sceneSelectionGroups.Move(prevIndex, newIndex);
-    }
-
-//----------------------------------------------------------------------------------------------------------------------
-
-    ///<inheritdoc/>
-    public void OnBeforeSerialize() {
-        m_sceneSelectionGroups.RemoveAll((g) => null == g);
-    }
-
-    ///<inheritdoc/>
-    public void OnAfterDeserialize() { }
-    
-
-//----------------------------------------------------------------------------------------------------------------------
-
-    [SerializeField] private List<SelectionGroup> m_sceneSelectionGroups = new List<SelectionGroup>();
-}
 }

--- a/Runtime/Scripts/SelectionGroupManager.cs
+++ b/Runtime/Scripts/SelectionGroupManager.cs
@@ -22,7 +22,7 @@ internal class SelectionGroupManager : MonoBehaviourSingleton<SelectionGroupMana
 
     public static void UpdateQueryResults() {
         foreach (var i in SelectionGroupManager.GetOrCreateInstance().m_sceneSelectionGroups) {
-            if (!string.IsNullOrEmpty(i.Query)) {
+            if (!string.IsNullOrEmpty(i.query)) {
                 i.UpdateQueryResults();
             }
         }
@@ -30,7 +30,7 @@ internal class SelectionGroupManager : MonoBehaviourSingleton<SelectionGroupMana
 
     internal IList<SelectionGroup> Groups => m_sceneSelectionGroups;
 
-    internal IEnumerable<string> GroupNames => m_sceneSelectionGroups.Select(g => g.Name);
+    internal IEnumerable<string> GroupNames => m_sceneSelectionGroups.Select(g => g.groupName);
 
 
     [Obsolete]
@@ -89,8 +89,8 @@ internal class SelectionGroupManager : MonoBehaviourSingleton<SelectionGroupMana
         Undo.RegisterCreatedObjectUndo(g, "New Scene Selection Group");
 #endif
         SelectionGroup group = g.AddComponent<SelectionGroup>();
-        group.Name        = groupName;
-        group.Color       = color;
+        group.groupName        = groupName;
+        group.color       = color;
         
         SelectionGroupsEditorProjectSettings projSettings = SelectionGroupsEditorProjectSettings.GetOrCreateInstance();
         for (int i = 0; i < (int)SelectionGroupToolType.BUILT_IN_MAX; ++i) {

--- a/Runtime/Scripts/SelectionGroupToolType.cs
+++ b/Runtime/Scripts/SelectionGroupToolType.cs
@@ -1,9 +1,9 @@
-namespace Unity.SelectionGroups {
-
-enum SelectionGroupToolType {
-    VISIBILITY = 0,
-    LOCK,
-    BUILT_IN_MAX,
+namespace Unity.SelectionGroups 
+{
+    internal enum SelectionGroupToolType 
+    {
+        Visibility = 0,
+        Lock,
+        BuiltInMAX,
+    }
 }
-
-} //end namespace

--- a/Runtime/Scripts/Settings/SelectionGroupsEditorProjectSettings.cs
+++ b/Runtime/Scripts/Settings/SelectionGroupsEditorProjectSettings.cs
@@ -3,69 +3,69 @@ using System.Collections.Generic;
 using Unity.FilmInternalUtilities;
 using UnityEngine;
 using UnityEngine.Assertions;
+using UnityEngine.Serialization;
 
 
-namespace Unity.SelectionGroups {
-
-[Json("ProjectSettings/SelectionGroupsSettings.asset")]
-[Serializable]
-internal class SelectionGroupsEditorProjectSettings : BaseJsonSingleton<SelectionGroupsEditorProjectSettings> {
-
-    protected override int GetLatestVersionV() => LATEST_VERSION;
-
-    protected override void UpgradeToLatestVersionV(int prevVersion, int curVersion) {
+namespace Unity.SelectionGroups 
+{
+    [Json("ProjectSettings/SelectionGroupsSettings.asset")]
+    [Serializable]
+    internal class SelectionGroupsEditorProjectSettings : BaseJsonSingleton<SelectionGroupsEditorProjectSettings> 
+    {
+        private enum SGProjectSettingsVersion 
+        {
+            Initial = 1,
+            EditorState_0_7_2, //The data structure of m_defaultGroupEditorToolStates was changed
+        };
         
-        if (prevVersion < (int) SGProjectSettingsVersion.EDITOR_STATE_0_7_2) {
-#pragma warning disable 612 //obsolete
-            if (null != m_defaultGroupEditorToolStatus) {
-                int numStates = m_defaultGroupEditorToolStatus.Count;
-                for (int i = 0; i < numStates; ++i) {
-                    m_defaultGroupEditorToolStates[i] = m_defaultGroupEditorToolStatus[i];
+        private const int kLatestVersion = (int) SGProjectSettingsVersion.EditorState_0_7_2; 
+        
+        [FormerlySerializedAs("m_groupsVisibleInHierarchy")] 
+        [SerializeField] private bool m_GroupsVisibleInHierarchy = true;
+        
+        [Obsolete]
+        [SerializeField] private List<bool> m_defaultGroupEditorToolStatus = null;
+        
+        [FormerlySerializedAs("m_defaultGroupEditorToolStates")] 
+        [SerializeField] private EditorToolStates m_DefaultGroupEditorToolStates = new EditorToolStates(); 
+        
+        protected override int GetLatestVersionV() => kLatestVersion;
+
+        protected override void UpgradeToLatestVersionV(int prevVersion, int curVersion) 
+        {
+            if (prevVersion < (int) SGProjectSettingsVersion.EditorState_0_7_2) 
+            {
+    #pragma warning disable 612 //obsolete
+                if (null != m_defaultGroupEditorToolStatus) 
+                {
+                    int numStates = m_defaultGroupEditorToolStatus.Count;
+                    for (int i = 0; i < numStates; ++i) 
+                    {
+                        m_DefaultGroupEditorToolStates[i] = m_defaultGroupEditorToolStatus[i];
+                    }
+                    m_defaultGroupEditorToolStatus = null;
+    #pragma warning restore 612
                 }
-                m_defaultGroupEditorToolStatus = null;
-#pragma warning restore 612
             }
         }
         
-    }
-    
-//----------------------------------------------------------------------------------------------------------------------
-
-    internal bool AreGroupsVisibleInHierarchy() => m_groupsVisibleInHierarchy; 
-    
-    internal void ShowGroupsInHierarchy(bool visible) {
-        m_groupsVisibleInHierarchy = visible; 
-    }
-
-    internal bool GetDefaultGroupEditorToolState(int toolID) {
-        if (m_defaultGroupEditorToolStates.TryGetValue(toolID, out bool status))
-            return status;
-        return false;
-    }
-
-    public void EnableDefaultGroupEditorTool(int toolID, bool toolEnabled) {
-        m_defaultGroupEditorToolStates[toolID] = toolEnabled;
-    }
-    
-    
-//----------------------------------------------------------------------------------------------------------------------
-    
-    [SerializeField] private bool m_groupsVisibleInHierarchy       = true;
-    
-    [Obsolete]
-    [SerializeField] List<bool> m_defaultGroupEditorToolStatus = null;
-    
-    [SerializeField] EditorToolStates m_defaultGroupEditorToolStates = new EditorToolStates(); 
-    
-//----------------------------------------------------------------------------------------------------------------------
-    private const int LATEST_VERSION = (int) SGProjectSettingsVersion.EDITOR_STATE_0_7_2; 
-    enum SGProjectSettingsVersion {
-        INITIAL = 1,
-        EDITOR_STATE_0_7_2, //The data structure of m_defaultGroupEditorToolStates was changed
+        internal bool AreGroupsVisibleInHierarchy() => m_GroupsVisibleInHierarchy; 
         
-    };
+        internal void ShowGroupsInHierarchy(bool visible) 
+        {
+            m_GroupsVisibleInHierarchy = visible; 
+        }
 
+        internal bool GetDefaultGroupEditorToolState(int toolID) 
+        {
+            if (m_DefaultGroupEditorToolStates.TryGetValue(toolID, out bool status))
+                return status;
+            return false;
+        }
 
+        public void EnableDefaultGroupEditorTool(int toolID, bool toolEnabled) 
+        {
+            m_DefaultGroupEditorToolStates[toolID] = toolEnabled;
+        }
+    }
 }
-
-} //end namespace

--- a/Runtime/Scripts/Utilities/SelectionGroupUtility.cs
+++ b/Runtime/Scripts/Utilities/SelectionGroupUtility.cs
@@ -7,46 +7,44 @@ using UnityEditor;
 
 namespace Unity.SelectionGroups
 {
-
-internal static class SelectionGroupUtility
-{
-    //move prevMembersSelection to targetGroup, and return the new members selection
-    internal static GroupMembersSelection MoveMembersSelectionToGroup(GroupMembersSelection prevMembersSelection, 
-        SelectionGroup targetGroup) 
+    internal static class SelectionGroupUtility
     {
-        GroupMembersSelection newMembersSelection = new GroupMembersSelection(prevMembersSelection);
-        RegisterUndo(targetGroup, "Move Members");
-            
-        foreach (KeyValuePair<SelectionGroup, OrderedSet<Object>> kv in prevMembersSelection) {
-            SelectionGroup prevGroup = kv.Key;
-            if (null == prevGroup)
-                continue;
+        //move prevMembersSelection to targetGroup, and return the new members selection
+        internal static GroupMembersSelection MoveMembersSelectionToGroup(GroupMembersSelection prevMembersSelection, 
+            SelectionGroup targetGroup) 
+        {
+            GroupMembersSelection newMembersSelection = new GroupMembersSelection(prevMembersSelection);
+            RegisterUndo(targetGroup, "Move Members");
                 
-            if (targetGroup == prevGroup)
-                continue;
+            foreach (KeyValuePair<SelectionGroup, OrderedSet<Object>> kv in prevMembersSelection) 
+            {
+                SelectionGroup prevGroup = kv.Key;
+                if (null == prevGroup)
+                    continue;
+                    
+                if (targetGroup == prevGroup)
+                    continue;
 
-            RegisterUndo(prevGroup, "Move Members");
-                                            
-            foreach (Object obj in kv.Value) {
-                newMembersSelection.AddObject(targetGroup, obj);
-                targetGroup.Add(obj);
-                prevGroup.Remove(obj);
-                newMembersSelection.RemoveObject(prevGroup, obj);
+                RegisterUndo(prevGroup, "Move Members");
+                                                
+                foreach (Object obj in kv.Value) 
+                {
+                    newMembersSelection.AddObject(targetGroup, obj);
+                    targetGroup.Add(obj);
+                    prevGroup.Remove(obj);
+                    newMembersSelection.RemoveObject(prevGroup, obj);
+                }
             }
+
+            return newMembersSelection;
         }
-
-        return newMembersSelection;
+        
+        private static void RegisterUndo(SelectionGroup group, string msg)
+        {
+    #if UNITY_EDITOR
+            Undo.RegisterCompleteObjectUndo(group, msg);
+            EditorUtility.SetDirty(group);
+    #endif
+        }
     }
-    
-    
-    static void RegisterUndo(SelectionGroup group, string msg)
-    {
-#if UNITY_EDITOR
-        Undo.RegisterCompleteObjectUndo(group, msg);
-        EditorUtility.SetDirty(group);
-#endif
-    }
-    
-
 }
-} //end namespace


### PR DESCRIPTION
Updated the SelectionGroups Editor and Runtime C# files to follow the conventions talked about in #216.

A basic over view of the changes are as follows.

### Class Indentation
Some classes had the same indentation as the namespace.
```cs
namespace Unity.SelectionGroups
{
public class FooClass
{
    public barProperty { get; set; }
}
}
```
They were changed to be indented from the namespace. This follows C# and Unity conventions. Also seems to follow what the newer code in SG does.
```cs
namespace Unity.SelectionGroups
{
    public class FooClass
    {
        public barProperty { get; set; }
    }
}
```

### Reposition Declarations
I rearranged definition location and order within a class, it now goes:
```
local classes/structs/enums
consts
statics
serialize private fields
non-serialized private fields
properties
events
methods
```
Having some sort of predefined order and location that is the same for all classes just makes it easier to read and add to the code since you will always know where to look for fields/classes/properties/etc.

### Curly Brace on New Line
Moved all curly braces (`{`, `}`) to be on there own line. This is how most of Unity's code (and C# in general) is formatted, and it seemed that is how most of the newer code in SG is as well.
Just having it be consistent makes the codebase easier to read.

### Renaming
Changed the name of all fields from either `private float fooField;` or `private float m_fooField;` to match Unity's naming convention of `private float m_FooField;` (Prefix with `m_` and then use PascelCase for the rest and not camelCase).

NOTE: `SelectionGroup.Name` was renamed to `SelectionGroup.groupName` as it would otherwise conflict with the `Object.name` property.

Changed the name of all enums and enum values to use PascelCase.

Changed the name of all static and consts to follow Unity's conventions.
`private const float FOO_CONST = 42;` to `private float const float kFooConst;` (Private consts prefix with `k` and use PascelCase for the rest of the name)
`private static float FOO_STATIC = 42;` to `private static float s_FooStatic = 42;` (Private statics prefix with `s_` and use PascelCase for the rest of the name)

### Explicit Accessibility
Changed all declarations to have their accessibility be explicit. Historically this is how Unity does it, it seems that most of the newer code in SG also does I think, and it is what I personally prefer so I went with it.
Having this be consistent over the whole code base (and within classes even) helps improve readability.

### Field Declaration/Assignment Spacing
There was extra spacing before/after/around some declarations so that they would line up.
```cs
private const string kAddGroup    = "Add Group";
private const int      kRightMargin = 16;
```
The extra spacing was removed as it was inconsistent with most other parts of the SG codebase and with Unity's convention.
```cs
private const string kAddGroup = "Add Group";
private const int kRightMargin = 16;
```

## Conclusion
These changes simply change the codebase to be more consistent over all, but within itself and with most of the other Unity code. 
Each commit is a single file change and there is a rough description of what changed. If you have any questions, concerns or anything you want clarification/explanation of please let me know.